### PR TITLE
Add path filters to CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,13 @@
 name: Docker Compose Build
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - 'docker/**'
+      - 'conf/**'
+      - 'compose.yml'
+      - 'lila-docker'
+      - 'scripts/**'
 
 jobs:
   build:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,6 +1,9 @@
 name: Rust
 
-on: [push, pull_request]
+on:
+  pull_request:
+    paths:
+      - 'command/**'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- **rust.yml**: `pull_request` only, triggered when `command/**` changes
- **build.yml**: `pull_request` only, triggered when Docker/config files change (`docker/**`, `conf/**`, `compose.yml`, `lila-docker`, `scripts/**`)
- Remove `push` trigger from both — PR validation is sufficient, `publish-image.yml` handles deployment on tags

## Test plan
- [ ] Verify CI does NOT trigger on docs/screenshot-only PRs
- [ ] Verify CI triggers on relevant file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)