### PR TITLE
Fix Test 23 flaky failure: add opening_pool cleanup

### DIFF
--- a/tests/e2e/helpers/cleanup.ts
+++ b/tests/e2e/helpers/cleanup.ts
@@ -16,6 +16,7 @@ export function cleanupPairData(users: string[]): void {
         { "challenger.user.id": { $in: ${JSON.stringify(users)} } },
         { "destUser.id": { $in: ${JSON.stringify(users)} } }
       ]});
+      db.opening_pool.deleteMany({ "_id": { $in: ${JSON.stringify(users)} } });
     `.replace(/\n/g, ' ');
     execSync(
       `docker exec chess-opening-duel-mongodb-1 mongosh lichess --quiet --eval '${mongoCommand}'`,


### PR DESCRIPTION
## Summary
- Add `opening_pool` collection cleanup to `cleanupPairData()` helper
- Test 23 was failing on repeated runs because pool modifications persisted between executions

## Test plan
- [x] Test 23 passes on first run
- [x] Test 23 passes on consecutive second run (previously failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)