### PR TITLE
🔒 Externalize secrets and add SMTP config

### DIFF
--- a/conf/mono.conf
+++ b/conf/mono.conf
@@ -1,7 +1,7 @@
 include "base"
 include "version"
 
-user.password.bpass.secret = "9qEYN0ThHer1KWLNekA76Q=="
+user.password.bpass.secret = ${?BPASS_SECRET}
 
 net.site.name = ${?LILA_SITE_NAME}
 net.domain = ${?LILA_DOMAIN}
@@ -9,6 +9,16 @@ net.socket.domains = [ ${?LILA_DOMAIN} ]
 net.asset.base_url = ${?LILA_URL}
 net.base_url = ${?LILA_URL}
 net.ratelimit = false
+
+mailer.primary.mock = false
+mailer.primary.tls = true
+mailer.primary.host = ${?SMTP_HOST}
+mailer.primary.port = ${?SMTP_PORT}
+mailer.primary.user = ${?SMTP_USER}
+mailer.primary.password = ${?SMTP_PASSWORD}
+mailer.primary.sender = ${?SMTP_SENDER}
+
+security.email_confirm.enabled = true
 
 push.firebase.mobile.url = "https://fcm.googleapis.com/v1/projects/lichess-testing-df65f/messages:send"
 push.firebase.mobile.json = "/opt/firebase-service-account.json"


### PR DESCRIPTION
## Summary
- Move `bpass.secret` from hardcoded value to `${?BPASS_SECRET}` env var
- Add Gmail SMTP mailer config with env vars (`SMTP_HOST`, `SMTP_PORT`, `SMTP_USER`, `SMTP_PASSWORD`, `SMTP_SENDER`)
- Enable email confirmation for production signup

## Test plan
- [ ] Deploy with env vars and verify new user signup sends verification email
- [ ] Verify existing password hashing works with new `BPASS_SECRET`

🤖 Generated with [Claude Code](https://claude.com/claude-code)