### PR TITLE
Fix mono build: install Python dependencies in dbbuilder stage

### DIFF
--- a/docker/mono.Dockerfile
+++ b/docker/mono.Dockerfile
@@ -27,6 +27,8 @@ COPY repos/lila-db-seed /lila-db-seed
 COPY scripts/reset-db.sh /scripts/reset-db.sh
 WORKDIR /lila-db-seed
 
+RUN pip3 install --break-system-packages -r spamdb/requirements.txt
+
 RUN mkdir /seeded \
     && mongod --fork --logpath /var/log/mongodb/mongod.log --dbpath /seeded \
     && /scripts/reset-db.sh


### PR DESCRIPTION
## Summary
- mono.Dockerfile의 `dbbuilder` 단계에서 `spamdb/requirements.txt` pip install 누락으로 빌드 실패
- `pymongo` 등 Python 패키지 설치 추가

## Test plan
- [ ] GitHub Actions에서 mono 이미지 빌드 성공 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)