### PR TITLE
Fix runtime DB seeding in mono image

### DIFF
--- a/docker/mono.Dockerfile
+++ b/docker/mono.Dockerfile
@@ -15,7 +15,6 @@ RUN apt update \
     && apt install -y \
         curl \
         python3-pip \
-        python3-venv \
     && apt clean
 
 ENV JAVA_HOME=/opt/java/openjdk
@@ -31,7 +30,8 @@ RUN pip3 install -r spamdb/requirements.txt
 
 RUN mkdir /seeded \
     && mongod --fork --logpath /var/log/mongodb/mongod.log --dbpath /seeded \
-    && /scripts/reset-db.sh
+    && /scripts/reset-db.sh \
+    && touch /seeded/.db_initialized
 
 ##################################################################################
 FROM sbtscala/scala-sbt:eclipse-temurin-alpine-25_36_1.11.6_3.7.3 AS lilawsbuilder
@@ -69,6 +69,7 @@ RUN apt update \
 COPY --from=dbbuilder /lila-db-seed /lila-db-seed
 COPY --from=dbbuilder /scripts /scripts
 COPY --from=dbbuilder /seeded /seeded
+RUN pip3 install -r /lila-db-seed/spamdb/requirements.txt
 COPY --from=lilawsbuilder /lila-ws/target /lila-ws/target
 COPY --from=lilabuilder /lila/bin/mongodb/indexes.js /lila/bin/mongodb/indexes.js
 COPY --from=lilabuilder /lila/target /lila/target


### PR DESCRIPTION
## Summary
- Add `.db_initialized` flag during build — fresh containers skip redundant `reset-db.sh`
- Install `spamdb/requirements.txt` in final stage — fallback for edge cases (volume recreation, manual flag deletion)
- Remove unused `python3-venv` from dbbuilder stage

## Context
v1.5.2 installs pymongo only in the dbbuilder build stage. The final runtime image lacks pymongo, so if `reset-db.sh` needs to run at container start (missing `.db_initialized` flag), it fails with `ModuleNotFoundError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)