### PR TITLE
release/v1.5.6

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -6,7 +6,7 @@ on:
       repo:
         description: 'Lila repository to build'
         required: false
-        default: 'Ootzk/chess-opening-duel-lila'
+        default: 'chess-opening-duel/lila'
         type: string
       branch:
         description: 'Branch to build'
@@ -36,7 +36,7 @@ jobs:
       - name: Setup build variables
         id: build_vars
         run: |
-          echo "repo=${{ github.event.inputs.repo || 'Ootzk/chess-opening-duel-lila' }}" >> $GITHUB_OUTPUT
+          echo "repo=${{ github.event.inputs.repo || 'chess-opening-duel/lila' }}" >> $GITHUB_OUTPUT
           echo "branch=${{ github.event.inputs.branch || 'master' }}" >> $GITHUB_OUTPUT
           if [ "${{ github.event.inputs.platforms || 'all' }}" = "all" ]; then
             echo "platforms=linux/amd64,linux/arm64" >> $GITHUB_OUTPUT
@@ -57,13 +57,13 @@ jobs:
       - name: Checkout lila-ws
         uses: actions/checkout@v5
         with:
-          repository: 'Ootzk/chess-opening-duel-lila-ws'
+          repository: 'chess-opening-duel/lila-ws'
           path: 'repos/lila-ws'
 
       - name: Checkout lila-db-seed
         uses: actions/checkout@v5
         with:
-          repository: 'Ootzk/chess-opening-duel-db-seed'
+          repository: 'chess-opening-duel/db-seed'
           path: 'repos/lila-db-seed'
 
       - name: Checkout lila-fishnet

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "repos/lila"]
 	path = repos/lila
-	url = https://github.com/Ootzk/chess-opening-duel-lila.git
+	url = https://github.com/chess-opening-duel/lila.git
 [submodule "repos/lila-db-seed"]
 	path = repos/lila-db-seed
-	url = https://github.com/Ootzk/chess-opening-duel-db-seed.git
+	url = https://github.com/chess-opening-duel/db-seed.git
 [submodule "repos/lila-ws"]
 	path = repos/lila-ws
-	url = https://github.com/Ootzk/chess-opening-duel-lila-ws.git
+	url = https://github.com/chess-opening-duel/lila-ws.git
 [submodule "repos/lila-fishnet"]
 	path = repos/lila-fishnet
 	url = https://github.com/lichess-org/lila-fishnet.git

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,7 +159,7 @@ chess-opening-duel/                 # lila-docker 포크 (메인)
 ├── scripts/                        # 헬퍼 스크립트
 ├── lila-docker                     # 실행 스크립트
 └── repos/                          # Git submodules
-    ├── lila/                       → chess-opening-duel-lila (Scala, 메인 서버)
+    ├── lila/                       → chess-opening-duel/lila (Scala, 메인 서버)
     ├── scalachess/                 → lichess-org/scalachess (체스 엔진, 원본)
     └── chessground/                → lichess-org/chessground (보드 UI, 원본)
 ```
@@ -184,7 +184,7 @@ docker compose exec lila ./lila.sh playRoutes  # 라우트 변경 시
 
 ## 릴리스 내역
 
-→ [GitHub Releases](https://github.com/Ootzk/chess-opening-duel/releases) 참조
+→ [GitHub Releases](https://github.com/chess-opening-duel/app/releases) 참조
 
 ## 버전 관리 및 Git
 

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Navigate to any opening page and use the **"Play as White" / "Play as Black"** b
 docker run -d --name chess-duel \
   -p 8080:8080 \
   -v chess-data:/seeded \
-  ghcr.io/ootzk/chess-opening-duel:latest
+  ghcr.io/chess-opening-duel/app:latest
 ```
 
 Open http://localhost:8080 and log in with any seeded account (password: `password`).
@@ -138,7 +138,7 @@ Open http://localhost:8080 and log in with any seeded account (password: `passwo
 See [CLAUDE.md](CLAUDE.md) for the full development guide, including Docker Compose setup, build commands, and project architecture.
 
 ```bash
-git clone --recursive https://github.com/Ootzk/chess-opening-duel.git
+git clone --recursive https://github.com/chess-opening-duel/app.git
 cd chess-opening-duel
 ./lila-docker start
 ```

--- a/compose-lila-ws-image.yml
+++ b/compose-lila-ws-image.yml
@@ -1,6 +1,6 @@
 services:
   lila_ws:
-    image: ghcr.io/ootzk/chess-opening-duel-lila-ws:latest
+    image: ghcr.io/chess-opening-duel/lila-ws:latest
     platform: linux/amd64
     restart: unless-stopped
     environment:

--- a/compose.yml
+++ b/compose.yml
@@ -76,7 +76,7 @@ services:
       - base
 
   mono:
-    image: ghcr.io/ootzk/chess-opening-duel:${MONO_TAG:-latest}
+    image: ghcr.io/chess-opening-duel/app:${MONO_TAG:-latest}
     restart: unless-stopped
     ports:
       - 8080:8080


### PR DESCRIPTION
## Summary
- 🚚 Migrate all repo references from `Ootzk/*` to `chess-opening-duel/*` org
- Update submodule URLs, GHCR image paths, GitHub Actions workflows, and documentation

## Changes
- `.gitmodules`: submodule URLs → `chess-opening-duel/{lila,lila-ws,db-seed}`
- `compose.yml`, `compose-lila-ws-image.yml`: GHCR image paths
- `.github/workflows/publish-image.yml`: CI repo references
- `README.md`, `CLAUDE.md`: documentation URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)