### PR TITLE
🐛 Add missing mono.conf copy in build-sbt

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -151,6 +151,10 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         uses: sbt/setup-sbt@v1
 
+      - name: Copy mono.conf
+        if: steps.check.outputs.skip != 'true'
+        run: cp conf/mono.conf repos/lila/conf/mono.conf
+
       - name: Generate lila version info
         if: steps.check.outputs.skip != 'true'
         working-directory: repos/lila


### PR DESCRIPTION
## Summary
- `build-sbt` 잡에 `mono.conf` 복사 단계 추가 (build-node에만 있던 것과 동일)
- v1.5.7 이미지에서 `ConfigException$Missing` 크래시 원인 해결

Fixes #97

## Test plan
- [ ] `workflow_dispatch`로 수동 빌드 트리거하여 이미지 정상 시작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)