### PR TITLE
🔧 Fix build badge: use event=push filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Chess Opening Duel
 
 [![Release](https://img.shields.io/github/v/release/chess-opening-duel/app?label=release&logo=github)](https://github.com/chess-opening-duel/app/releases)
-[![Build](https://img.shields.io/github/actions/workflow/status/chess-opening-duel/app/publish-image.yml?branch=main&label=build&logo=github)](https://github.com/chess-opening-duel/app/actions/workflows/publish-image.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/chess-opening-duel/app/publish-image.yml?event=push&label=build&logo=github)](https://github.com/chess-opening-duel/app/actions/workflows/publish-image.yml)
 [![GHCR](https://ghcr-badge.egpl.dev/chess-opening-duel/app/latest_tag?trim=major&label=image)](https://github.com/chess-opening-duel/app/pkgs/container/app)
 
 A custom 1v1 chess game mode built on [lichess](https://github.com/lichess-org) [components](https://github.com/lichess-org/lila-docker). Players ban and pick from a pool of chess openings, then compete in a best-of-5 series starting from those positions.


### PR DESCRIPTION
## Summary
- Build 배지 `?branch=main` → `?event=push`로 변경
- 태그 트리거 빌드가 branch 필터에 걸려 failing으로 표시되던 문제 수정

## Test plan
- [x] `?event=push` URL로 passing 확인 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)