### PR TITLE
Release v1.5.8

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -151,6 +151,10 @@ jobs:
         if: steps.check.outputs.skip != 'true'
         uses: sbt/setup-sbt@v1
 
+      - name: Copy mono.conf
+        if: steps.check.outputs.skip != 'true'
+        run: cp conf/mono.conf repos/lila/conf/mono.conf
+
       - name: Generate lila version info
         if: steps.check.outputs.skip != 'true'
         working-directory: repos/lila

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Chess Opening Duel
 
 [![Release](https://img.shields.io/github/v/release/chess-opening-duel/app?label=release&logo=github)](https://github.com/chess-opening-duel/app/releases)
-[![Build](https://img.shields.io/github/actions/workflow/status/chess-opening-duel/app/publish-image.yml?branch=main&label=build&logo=github)](https://github.com/chess-opening-duel/app/actions/workflows/publish-image.yml)
+[![Build](https://img.shields.io/github/actions/workflow/status/chess-opening-duel/app/publish-image.yml?event=push&label=build&logo=github)](https://github.com/chess-opening-duel/app/actions/workflows/publish-image.yml)
 [![GHCR](https://ghcr-badge.egpl.dev/chess-opening-duel/app/latest_tag?trim=major&label=image)](https://github.com/chess-opening-duel/app/pkgs/container/app)
 
 A custom 1v1 chess game mode built on [lichess](https://github.com/lichess-org) [components](https://github.com/lichess-org/lila-docker). Players ban and pick from a pool of chess openings, then compete in a best-of-5 series starting from those positions.


### PR DESCRIPTION
## Summary
- 🐛 build-sbt job에 누락된 mono.conf 복사 스텝 추가 (#98)
- 🔧 Build 배지 `?branch=main` → `?event=push` 필터 수정 (#99)

## Test plan
- [x] Build 배지 passing 확인
- [x] GHCR 배지 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)