### PR TITLE
🔧 Add fishnet --no-conf and per-process JVM heap settings (#106)

### DIFF
--- a/conf/supervisord.conf
+++ b/conf/supervisord.conf
@@ -35,6 +35,7 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+environment=JAVA_OPTS="-Xms512m -Xmx512m"
 
 [program:lila]
 # sleep 5 seconds to give mongodb time to start
@@ -44,6 +45,7 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
+environment=JAVA_OPTS="-Xms2g -Xmx2g"
 
 [program:lila_fishnet]
 # sleep 8 seconds to give redis time to start
@@ -53,11 +55,11 @@ autorestart=true
 redirect_stderr=true
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
-environment=REDIS_HOST="127.0.0.1",HTTP_PORT="9665"
+environment=REDIS_HOST="127.0.0.1",HTTP_PORT="9665",JAVA_OPTS="-Xms256m -Xmx256m"
 
 [program:fishnet_play]
 # sleep 15 seconds to give lila-fishnet time to start
-command=bash -c 'sleep 15 && /fishnet --endpoint http://127.0.0.1:9665/fishnet --max-backoff 5'
+command=bash -c 'sleep 15 && /fishnet --no-conf --endpoint http://127.0.0.1:9665/fishnet --max-backoff 5'
 autostart=true
 autorestart=true
 redirect_stderr=true
@@ -66,7 +68,7 @@ stdout_logfile_maxbytes=0
 
 [program:fishnet_analysis]
 # sleep 12 seconds to give lila time to start
-command=bash -c 'sleep 12 && /fishnet --endpoint http://127.0.0.1:9663/fishnet --max-backoff 5'
+command=bash -c 'sleep 12 && /fishnet --no-conf --endpoint http://127.0.0.1:9663/fishnet --max-backoff 5'
 autostart=true
 autorestart=true
 redirect_stderr=true

--- a/docker/mono.Dockerfile
+++ b/docker/mono.Dockerfile
@@ -43,7 +43,6 @@ RUN apt update \
     && mkdir -p /var/log/supervisor
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV JAVA_OPTS="-Xms4g -Xmx4g"
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ENV LANG=C.utf8
 COPY --from=eclipse-temurin:25-jdk $JAVA_HOME $JAVA_HOME


### PR DESCRIPTION
## Summary
- fishnet에 `--no-conf` 플래그 추가하여 비대화형 환경에서 stdin 블로킹(좀비) 방지
- 프로세스별 JVM 힙 개별 설정 (lila 2G, lila-ws 512M, lila-fishnet 256M → 총 2.75GB, 기존 12GB 대비 77% 절감)
- Dockerfile의 글로벌 `JAVA_OPTS` ENV 삭제

## Test plan
- [ ] mono 이미지 빌드 후 컨테이너 기동
- [ ] fishnet 프로세스가 좀비 없이 정상 동작 확인
- [ ] 각 JVM 프로세스 힙 크기가 개별 설정값대로 할당되었는지 확인

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)