### PR TITLE
🐛 Fix CI build: add GHCR login for private image pull

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,10 @@ on:
       - 'lila-docker'
       - 'scripts/**'
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,5 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - run: ./lila-docker build
       - run: docker image ls

--- a/lila-docker
+++ b/lila-docker
@@ -80,8 +80,7 @@ run_down() {
 
 all_profiles() {
     # return all Docker Compose profiles as a comma-separated string
-    # exclude 'quick' profile (mono image requires private registry auth)
-    docker compose config --profiles | grep -v '^quick$' | xargs | sed -e 's/ /,/g'
+    docker compose config --profiles | xargs | sed -e 's/ /,/g'
 }
 
 build_all_profiles() {

--- a/lila-docker
+++ b/lila-docker
@@ -80,7 +80,8 @@ run_down() {
 
 all_profiles() {
     # return all Docker Compose profiles as a comma-separated string
-    docker compose config --profiles | xargs | sed -e 's/ /,/g'
+    # exclude 'quick' profile (mono image requires private registry auth)
+    docker compose config --profiles | grep -v '^quick$' | xargs | sed -e 's/ /,/g'
 }
 
 build_all_profiles() {


### PR DESCRIPTION
## Summary
- `build.yml` CI에서 `./lila-docker build` 실행 시 private GHCR 이미지(`mono`, `lila-ws`) pull 실패 수정
- `docker/login-action`으로 GHCR 인증 추가 + `packages: read` 권한 명시

## Related
- Failed run: https://github.com/chess-opening-duel/app/actions/runs/22830383456

## Test plan
- [ ] PR의 CI(`Docker Compose Build`)가 정상 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)