### PR TITLE
✅ Clean up E2E test organization: remove numbers, add tags, fix flaky

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -27,19 +27,21 @@ tests/e2e/
 │   ├── scenarios.ts       # 테스트 시나리오 매트릭스 (PickBanBehavior, testScenarios)
 │   └── series.ts          # 시리즈 조작 헬퍼 (selectOpenings, confirm 등)
 └── specs/
-    ├── opening-pool.spec.ts           # Opening Pool 페이지 테스트 (Test 20)
-    ├── series-banpick.spec.ts         # 밴픽 플로우 테스트 (Test 0~6)
-    ├── series-countdown.spec.ts       # Countdown 테스트 (Test 12~13)
-    ├── series-disconnect.spec.ts      # Disconnect/Abort 테스트 (Test 7~8, 14~15)
-    ├── series-forfeit.spec.ts         # Series Forfeit 테스트 (Test 9~10)
-    ├── series-finished.spec.ts        # Finished Page + Rematch 테스트 (Test 11)
-    ├── series-pool-exhaustion.spec.ts # Pool Exhaustion → Draw 테스트 (Test 17)
-    ├── series-resting.spec.ts         # Resting Phase 테스트 (Test 18~19)
-    ├── series-nostart.spec.ts         # NoStart 테스트 (Test 20~21)
-    ├── opening-pool-customize.spec.ts # Opening Pool 커스터마이즈 테스트 (Test 22)
-    ├── series-reconnect-banner.spec.ts # Reconnection 배너 테스트 (Test 26)
-    ├── series-lobby.spec.ts           # Lobby 매칭 테스트 (Test 27)
-    └── series-ai.spec.ts             # AI Opening Duel 테스트 (Test 28)
+    ├── series-banpick.spec.ts         # 밴픽 플로우 (7 시나리오)
+    ├── series-countdown.spec.ts       # Countdown 표시/취소
+    ├── series-disconnect.spec.ts      # Disconnect/Abort (Pick, Ban, Game, Resting, Selecting)
+    ├── series-forfeit.spec.ts         # Series Forfeit
+    ├── series-finished.spec.ts        # Finished Page + Rematch
+    ├── series-finished-mobile.spec.ts # Finished Page 모바일 스크롤
+    ├── series-resting.spec.ts         # Resting Phase (confirm, timeout)
+    ├── series-nostart.spec.ts         # NoStart (미착수 패배)
+    ├── series-pool-exhaustion.spec.ts # Pool Exhaustion → Draw
+    ├── series-reconnect-banner.spec.ts # Reconnection 배너
+    ├── series-lobby.spec.ts           # Lobby 매칭
+    ├── series-ai.spec.ts              # AI Opening Duel
+    ├── series-color-mismatch.spec.ts  # Opening Color Mismatch 버그
+    ├── opening-pool.spec.ts           # Opening Pool 페이지
+    └── opening-pool-customize.spec.ts # Opening Pool 커스터마이즈
 ```
 
 ## 테스트 계정 생성
@@ -83,31 +85,40 @@ const users = [
 
 각 테스트는 고유한 계정 쌍을 사용하며, pick/ban 행동과 시리즈 결과를 정의함.
 
-| # | P1 | P2 | pick | ban | series result | games | score | 특징 |
-|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---|
-| 0 | elena | hans | ✅/✅ | ✅/✅ | 0 - ½ - 1 - 1 | 4 | 2.5-1.5 | 역전승 |
-| 1 | yulia | luis | ✅/⏰ | ✅/🚫 | 1 - 1 - 1 | 3 | 3-0 | 3연승 |
-| 2 | ana | lola | ⏰/✅ | 🚫/✅ | 0 - 1 - 0 - 1 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
-| 3 | carlos | nina | ⚠️/✅ | ✅/⚠️ | 0 - 0 - 1 - 1 - 1 | 5 | 3-2 | 0-2 역전 |
-| 4 | oscar | petra | ✅/⚠️ | ⚠️/✅ | 1 - ½ - 1 | 3 | 2.5-0.5 | 조기승리 |
-| 5 | boris | david | 🚫/✅ | ✅/⏰ | 1 - 0 - 1 - 0 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
-| 6 | mei | ivan | ✅/🚫 | ⏰/✅ | 0 - 1 - 1 - 1 | 4 | 3-1 | 4경기 |
-| 7 | angel | bobby | ✅/🔌 | - | - | - | abort | Pick disconnect |
-| 8 | marcel | vera | ✅/✅ | ✅/🔌 | - | - | abort | Ban disconnect |
-| 9 | fatima | diego | ✅/✅ | ✅/✅ | forfeit(moves) | 1 | forfeit | P1 forfeit after moves |
-| 10 | salma | benjamin | ✅/✅ | ✅/✅ | forfeit(no moves) | 1 | forfeit | P1 forfeit before moves |
-| 11 | patricia | adriana | ✅/✅ | ✅/✅ | 1 - 1 - 1 | 3 | 3-0 | Finished page + rematch |
-| 12 | mary | jose | ✅/✅ | ✅/✅ | - | 1 | - | Countdown 표시 + 감소 |
-| 13 | iryna | pedro | ✅/✅ | ✅/✅ | - | 1 | - | Countdown cancel + 재시작 |
-| 14 | aaron | jacob | ✅/✅ | ✅/✅ | disconnect(game) | 1 | 1-0 | 게임 중 disconnect → game loss, series continues |
-| 15 | svetlana | qing | ✅/✅ | ✅/✅ | 0 - 0 + disconnect | 3 | 1-2 | 0-2 후 game 3 disconnect → game loss, series continues |
-| 17 | dmitry | milena | ✅/✅ | ✅/✅ | ½ - ½ - ½ - ½ - ½ - ½ | 6 | 3-3 draw | 풀 소진 → 시리즈 Draw |
-| 18 | yaroslava | ekaterina | ✅/✅ | ✅/✅ | P2 resign + resting | 2 | - | Resting: confirm→cancel→re-confirm→countdown |
-| 19 | margarita | yevgeny | ✅/✅ | ✅/✅ | P1 resign + resting | 2 | - | Resting: confirm→cancel→30s timeout |
-| 20 | elena | - | - | - | - | - | - | Opening Pool 페이지 접근 + 렌더링 확인 |
-| 21 | kwame | sonia | ✅/✅ | ✅/✅ | 1 + selecting timeout | 2 | - | Selecting timeout → 랜덤 선택, game 2 시작 |
-| 22 | tomoko | renata | ✅/✅ | ✅/✅ | 0 + resting both DC | 1 | abort | Resting 양측 DC → 시리즈 abort |
-| 27 | elizabeth | dae | ✅/✅ | ✅/✅ | 0 (1 game only) | 1 | active | Lobby hook 매칭 → 시리즈 생성 |
+| Spec 파일 | P1 | P2 | pick | ban | series result | games | score | 시나리오 |
+|:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---|
+| banpick | elena | hans | ✅/✅ | ✅/✅ | 0 - ½ - 1 - 1 | 4 | 2.5-1.5 | 역전승 |
+| banpick | yulia | luis | ✅/⏰ | ✅/🚫 | 1 - 1 - 1 | 3 | 3-0 | 3연승 |
+| banpick | ana | lola | ⏰/✅ | 🚫/✅ | 0 - 1 - 0 - 1 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
+| banpick | carlos | nina | ⚠️/✅ | ✅/⚠️ | 0 - 0 - 1 - 1 - 1 | 5 | 3-2 | 0-2 역전 |
+| banpick | oscar | petra | ✅/⚠️ | ⚠️/✅ | 1 - ½ - 1 | 3 | 2.5-0.5 | 조기승리 |
+| banpick | boris | david | 🚫/✅ | ✅/⏰ | 1 - 0 - 1 - 0 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
+| banpick | mei | ivan | ✅/🚫 | ⏰/✅ | 0 - 1 - 1 - 1 | 4 | 3-1 | 4경기 |
+| disconnect | angel | bobby | ✅/🔌 | - | - | - | abort | Pick disconnect |
+| disconnect | marcel | vera | ✅/✅ | ✅/🔌 | - | - | abort | Ban disconnect |
+| forfeit | fatima | diego | ✅/✅ | ✅/✅ | forfeit(moves) | 1 | forfeit | P1 forfeit after moves |
+| forfeit | salma | benjamin | ✅/✅ | ✅/✅ | forfeit(no moves) | 1 | forfeit | P1 forfeit before moves |
+| finished | patricia | adriana | ✅/✅ | ✅/✅ | 1 - 1 - 1 | 3 | 3-0 | Finished page + rematch |
+| countdown | mary | jose | ✅/✅ | ✅/✅ | - | 1 | - | Countdown 표시 + 감소 |
+| countdown | iryna | pedro | ✅/✅ | ✅/✅ | - | 1 | - | Countdown cancel + 재시작 |
+| disconnect | aaron | jacob | ✅/✅ | ✅/✅ | disconnect(game) | 1 | 1-0 | Game DC → game loss |
+| disconnect | svetlana | qing | ✅/✅ | ✅/✅ | 0 - 0 + disconnect | 3 | 1-2 | Game 3 DC after 0-2 |
+| pool-exhaustion | dmitry | milena | ✅/✅ | ✅/✅ | ½ - ½ - ½ - ½ - ½ - ½ | 6 | 3-3 draw | 풀 소진 → 시리즈 Draw |
+| resting | yaroslava | ekaterina | ✅/✅ | ✅/✅ | P2 resign + resting | 2 | - | Resting: confirm→cancel→re-confirm→countdown |
+| resting | margarita | yevgeny | ✅/✅ | ✅/✅ | P1 resign + resting | 2 | - | Resting: confirm→cancel→30s timeout |
+| disconnect | kwame | sonia | ✅/✅ | ✅/✅ | 1 + selecting timeout | 2 | - | Selecting timeout → 랜덤 선택 |
+| disconnect | tomoko | renata | ✅/✅ | ✅/✅ | 0 + resting both DC | 1 | abort | Resting 양측 DC → abort |
+| disconnect | yarah | suresh | ✅/✅ | ✅/✅ | 0 + resting 1 DC | 1 | forfeit | Resting 1 DC → forfeit |
+| nostart | yunel | idris | ✅/✅ | ✅/✅ | nostart | 1 | - | NoStart: 양측 미착수 |
+| nostart | aleksandr | veer | ✅/✅ | ✅/✅ | nostart | 1 | - | NoStart: 후수 미착수 |
+| nostart | aleksandr | veer | ✅/✅ | ✅/✅ | nostart | 1 | - | NoStart: 타이머 지연 |
+| reconnect-banner | frances | emmanuel | ✅/✅ | - | - | - | - | Reconnection 배너 표시 |
+| lobby | elizabeth | dae | ✅/✅ | ✅/✅ | 0 (1 game only) | 1 | active | Lobby hook 매칭 → 시리즈 생성 |
+| ai | mateo | - | - | - | - | 1 | forfeit | AI vs Stockfish |
+| pool | elena | - | - | - | - | - | - | Opening Pool 페이지 렌더링 |
+| pool-customize | ramesh | nushi | ✅/✅ | ✅/✅ | - | 1 | - | 커스텀 pool → Pick Phase |
+| color-mismatch | akeem | rudra | ✅/✅ | ✅/✅ | - | 1 | - | Opening color mismatch 버그 |
+| finished-mobile | gabriela | guang | ✅/✅ | ✅/✅ | 1 - 1 - 1 | 3 | 3-0 | Finished 모바일 스크롤 |
 
 ## Pick/Ban 행동 타입
 
@@ -123,11 +134,11 @@ const users = [
 
 | 행동 | pick-p1 | pick-p2 | ban-p1 | ban-p2 |
 |:---:|:---:|:---:|:---:|:---:|
-| confirm | 0,1,4,6 | 0,2,3,5 | 0,1,3,5 | 0,2,4,6 |
-| full-timeout | 2 | 1 | 6 | 5 |
-| partial-timeout | 3 | 4 | 4 | 3 |
-| none-timeout | 5 | 6 | 2 | 1 |
-| disconnected | - | 7 | - | 8 |
+| confirm | elena,yulia,oscar,mei | elena,ana,carlos,boris | elena,yulia,carlos,boris | elena,ana,oscar,mei |
+| full-timeout | ana | yulia | mei | boris |
+| partial-timeout | carlos | oscar | oscar | carlos |
+| none-timeout | boris | mei | ana | yulia |
+| disconnected | - | angel | - | marcel |
 
 → 16개 조합 (4 행동 × 4 위치) 모두 커버됨 + disconnect 2개
 
@@ -144,19 +155,22 @@ P1 관점에서 각 게임 결과를 `-`로 구분:
 
 **1. 테스트 이름 형식:**
 ```typescript
-test('[Test 0] 역전승 4게임', async ({ browser }) => {...});
+// describe: "유저 vs 유저: 시나리오"
+// test: 서술적 시나리오 설명
+test.describe('elena vs hans: 역전승 4게임', () => {
+  test('역전승 4게임', async ({ browser }) => {...});
+});
 ```
 
 **2. 테스트 구조:**
 ```typescript
-test.describe('Test 0: elena vs hans', () => {
+test.describe('elena vs hans: 역전승 4게임', () => {
   test.describe.configure({ timeout: 120000 });
-  const pair = testPairs[0];  // 또는 testPairs.test0
   const pairUsers = ['elena', 'hans'];
 
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 0] 역전승 4게임', async ({ browser }) => {
+  test('역전승 4게임', async ({ browser }) => {
     // 1. 시리즈 생성 + 밴픽 완료
     await completeBanPickPhase(player1, player2, {
       pick: { p1: 'confirm', p2: 'confirm' },
@@ -177,7 +191,7 @@ test.describe('Test 0: elena vs hans', () => {
 ```
 
 **3. 새 테스트 추가 시:**
-1. 매트릭스에 새 행 추가 (# 증가)
+1. 매트릭스에 새 행 추가 (spec 파일명 + 시나리오 설명)
 2. 새 계정 쌍 추가 (uids.txt, global-setup.ts, auth.ts)
 3. 기존 테스트와 중복되지 않는 pick/ban 조합 선택
 4. series result로 테스트할 시나리오 정의
@@ -208,7 +222,7 @@ test.describe('Test 0: elena vs hans', () => {
 - 테스트 실행 시 항상 HTML 리포트 사용 (`npm test` 후 `npm run report`)
 - 테스트 실패 시 리포트 확인을 유저에게 안내
 - 새 시나리오 추가 시 매트릭스 기반으로 설계
-- 테스트 이름은 `[Test #] 설명` 형식 유지
+- 테스트 이름은 서술적으로 작성 (번호 사용 금지)
 
 ## 실전 팁
 
@@ -220,33 +234,39 @@ test.describe('Test 0: elena vs hans', () => {
 
 ## 테스트 계정 쌍 목록
 
-| Pair | P1 | P2 | 용도 | Spec 파일 |
-|:---:|:---:|:---:|:---|:---|
-| 1 | elena | hans | 밴픽 Test 0 | series-banpick |
-| 2 | boris | david | 밴픽 Test 5 | series-banpick |
-| 3 | yulia | luis | 밴픽 Test 1 | series-banpick |
-| 4 | mei | ivan | 밴픽 Test 6 | series-banpick |
-| 5 | ana | lola | 밴픽 Test 2 | series-banpick |
-| 6 | carlos | nina | 밴픽 Test 3 | series-banpick |
-| 7 | oscar | petra | 밴픽 Test 4 | series-banpick |
-| 8 | angel | bobby | Disconnect Test 7 | series-disconnect |
-| 9 | marcel | vera | Disconnect Test 8 | series-disconnect |
-| 10 | fatima | diego | Forfeit Test 9 | series-forfeit |
-| 11 | salma | benjamin | Forfeit Test 10 | series-forfeit |
-| 12 | patricia | adriana | Finished + Rematch Test 11 | series-finished |
-| 13 | mary | jose | Countdown Test 12 | series-countdown |
-| 14 | iryna | pedro | Countdown Test 13 | series-countdown |
-| 15 | aaron | jacob | Game Disconnect Test 14 | series-disconnect |
-| 16 | svetlana | qing | Game Disconnect Test 15 | series-disconnect |
-| 17 | dmitry | milena | Pool Exhaustion Test 17 | series-pool-exhaustion |
-| 18 | yaroslava | ekaterina | Resting confirm Test 18 | series-resting |
-| 19 | margarita | yevgeny | Resting timeout Test 19 | series-resting |
-| 23 | kwame | sonia | Selecting timeout Test 21 | series-disconnect |
-| 24 | tomoko | renata | Resting both DC Test 22 | series-disconnect |
-| 25 | yarah | suresh | Resting 1 DC Test 25 | series-disconnect |
-| 26 | frances | emmanuel | Reconnect banner Test 26 | series-reconnect-banner |
-| 27 | elizabeth | dae | Lobby matching Test 27 | series-lobby |
-| Solo | mateo | - | AI Opening Duel Test 28 | series-ai |
+| P1 | P2 | 시나리오 | Spec 파일 |
+|:---:|:---:|:---|:---|
+| elena | hans | 밴픽 역전승 | series-banpick |
+| boris | david | 밴픽 서든데스 P1 선행 | series-banpick |
+| yulia | luis | 밴픽 3연승 | series-banpick |
+| mei | ivan | 밴픽 4경기 | series-banpick |
+| ana | lola | 밴픽 서든데스 P2 선행 | series-banpick |
+| carlos | nina | 밴픽 0-2 역전 | series-banpick |
+| oscar | petra | 밴픽 조기승리 | series-banpick |
+| angel | bobby | Pick disconnect → abort | series-disconnect |
+| marcel | vera | Ban disconnect → abort | series-disconnect |
+| fatima | diego | Forfeit after moves | series-forfeit |
+| salma | benjamin | Forfeit before moves | series-forfeit |
+| patricia | adriana | Finished page + rematch | series-finished |
+| mary | jose | Countdown 표시 + 감소 | series-countdown |
+| iryna | pedro | Countdown cancel + 재시작 | series-countdown |
+| aaron | jacob | Game DC → game loss | series-disconnect |
+| svetlana | qing | Game 3 DC after 0-2 | series-disconnect |
+| dmitry | milena | Pool exhaustion → Draw | series-pool-exhaustion |
+| yaroslava | ekaterina | Resting confirm | series-resting |
+| margarita | yevgeny | Resting timeout | series-resting |
+| yunel | idris | NoStart neither moves | series-nostart |
+| aleksandr | veer | NoStart second mover / timer | series-nostart |
+| ramesh | nushi | Pool customize → Pick Phase | opening-pool-customize |
+| kwame | sonia | Selecting timeout → random | series-disconnect |
+| tomoko | renata | Resting both DC → abort | series-disconnect |
+| yarah | suresh | Resting 1 DC → forfeit | series-disconnect |
+| frances | emmanuel | Reconnection banner | series-reconnect-banner |
+| elizabeth | dae | Lobby hook matching | series-lobby |
+| mateo | - | AI vs Stockfish | series-ai |
+| akeem | rudra | Opening color mismatch | series-color-mismatch |
+| gabriela | guang | Finished mobile scroll | series-finished-mobile |
+| elena | - | Opening Pool 페이지 | opening-pool |
 
 > **중요**: 각 쌍은 하나의 테스트에서만 사용 (병렬 충돌 방지)
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -503,7 +503,7 @@ function cleanupPairData(usernames: string[]) {
       { "destUser.id": { $in: ${JSON.stringify(usernames)} } }
     ]});
   `.replace(/\n/g, ' ');
-  execSync(`docker exec chess-opening-duel-mongodb-1 mongosh lichess --quiet --eval '${mongoCommand}'`);
+  execSync(`docker exec app-mongodb-1 mongosh lichess --quiet --eval '${mongoCommand}'`);
 }
 ```
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -27,7 +27,7 @@ tests/e2e/
 │   ├── scenarios.ts       # 테스트 시나리오 매트릭스 (PickBanBehavior, testScenarios)
 │   └── series.ts          # 시리즈 조작 헬퍼 (selectOpenings, confirm 등)
 └── specs/
-    ├── series-banpick.spec.ts         # 밴픽 플로우 (7 시나리오)
+    ├── series-scenarios.spec.ts       # 시리즈 시나리오 (7개: 역전, 서든데스 등)
     ├── series-countdown.spec.ts       # Countdown 표시/취소
     ├── series-disconnect.spec.ts      # Disconnect/Abort (Pick, Ban, Game, Resting, Selecting)
     ├── series-forfeit.spec.ts         # Series Forfeit
@@ -87,13 +87,13 @@ const users = [
 
 | Spec 파일 | P1 | P2 | pick | ban | series result | games | score | 시나리오 |
 |:---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---|
-| banpick | elena | hans | ✅/✅ | ✅/✅ | 0 - ½ - 1 - 1 | 4 | 2.5-1.5 | 역전승 |
-| banpick | yulia | luis | ✅/⏰ | ✅/🚫 | 1 - 1 - 1 | 3 | 3-0 | 3연승 |
-| banpick | ana | lola | ⏰/✅ | 🚫/✅ | 0 - 1 - 0 - 1 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
-| banpick | carlos | nina | ⚠️/✅ | ✅/⚠️ | 0 - 0 - 1 - 1 - 1 | 5 | 3-2 | 0-2 역전 |
-| banpick | oscar | petra | ✅/⚠️ | ⚠️/✅ | 1 - ½ - 1 | 3 | 2.5-0.5 | 조기승리 |
-| banpick | boris | david | 🚫/✅ | ✅/⏰ | 1 - 0 - 1 - 0 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
-| banpick | mei | ivan | ✅/🚫 | ⏰/✅ | 0 - 1 - 1 - 1 | 4 | 3-1 | 4경기 |
+| scenarios | elena | hans | ✅/✅ | ✅/✅ | 0 - ½ - 1 - 1 | 4 | 2.5-1.5 | 역전승 |
+| scenarios | yulia | luis | ✅/⏰ | ✅/🚫 | 1 - 1 - 1 | 3 | 3-0 | 3연승 |
+| scenarios | ana | lola | ⏰/✅ | 🚫/✅ | 0 - 1 - 0 - 1 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
+| scenarios | carlos | nina | ⚠️/✅ | ✅/⚠️ | 0 - 0 - 1 - 1 - 1 | 5 | 3-2 | 0-2 역전 |
+| scenarios | oscar | petra | ✅/⚠️ | ⚠️/✅ | 1 - ½ - 1 | 3 | 2.5-0.5 | 조기승리 |
+| scenarios | boris | david | 🚫/✅ | ✅/⏰ | 1 - 0 - 1 - 0 - ½ - 1 | 6 | 3.5-2.5 | 서든데스 |
+| scenarios | mei | ivan | ✅/🚫 | ⏰/✅ | 0 - 1 - 1 - 1 | 4 | 3-1 | 4경기 |
 | disconnect | angel | bobby | ✅/🔌 | - | - | - | abort | Pick disconnect |
 | disconnect | marcel | vera | ✅/✅ | ✅/🔌 | - | - | abort | Ban disconnect |
 | forfeit | fatima | diego | ✅/✅ | ✅/✅ | forfeit(moves) | 1 | forfeit | P1 forfeit after moves |
@@ -217,6 +217,21 @@ test.describe('elena vs hans: 역전승 4게임', () => {
 | OFF | 6 | 10/12 | 4.9m |
 | **OFF** | **3** | **12/12** | **6.4m** |
 
+## 태그 기반 필터 실행
+
+각 테스트에 `@phase:*`, `@feature:*`, `@scope:*` 태그가 부여되어 관심사별 실행 가능.
+
+```bash
+npx playwright test --grep @feature:disconnect   # disconnect 관련만
+npx playwright test --grep @scope:quick          # 빠른 테스트만 (<2분)
+npx playwright test --grep @phase:resting        # resting 페이즈 포함 테스트
+npx playwright test --grep-invert @scope:slow    # 느린 테스트 제외
+```
+
+**Phase tags** (`@phase:*`): `pick`, `ban`, `game`, `resting`, `selecting` — 실제 거치는 페이즈
+**Feature tags** (`@feature:*`): `disconnect`, `forfeit`, `ai`, `pool`, `countdown`, `rematch`, `mobile`, `lobby`, `reconnect`, `nostart`
+**Scope tags** (`@scope:*`): `quick` (<2분), `slow` (>2분)
+
 ## Claude 가이드라인
 
 - 테스트 실행 시 항상 HTML 리포트 사용 (`npm test` 후 `npm run report`)
@@ -236,13 +251,13 @@ test.describe('elena vs hans: 역전승 4게임', () => {
 
 | P1 | P2 | 시나리오 | Spec 파일 |
 |:---:|:---:|:---|:---|
-| elena | hans | 밴픽 역전승 | series-banpick |
-| boris | david | 밴픽 서든데스 P1 선행 | series-banpick |
-| yulia | luis | 밴픽 3연승 | series-banpick |
-| mei | ivan | 밴픽 4경기 | series-banpick |
-| ana | lola | 밴픽 서든데스 P2 선행 | series-banpick |
-| carlos | nina | 밴픽 0-2 역전 | series-banpick |
-| oscar | petra | 밴픽 조기승리 | series-banpick |
+| elena | hans | 밴픽 역전승 | series-scenarios |
+| boris | david | 밴픽 서든데스 P1 선행 | series-scenarios |
+| yulia | luis | 밴픽 3연승 | series-scenarios |
+| mei | ivan | 밴픽 4경기 | series-scenarios |
+| ana | lola | 밴픽 서든데스 P2 선행 | series-scenarios |
+| carlos | nina | 밴픽 0-2 역전 | series-scenarios |
+| oscar | petra | 밴픽 조기승리 | series-scenarios |
 | angel | bobby | Pick disconnect → abort | series-disconnect |
 | marcel | vera | Ban disconnect → abort | series-disconnect |
 | fatima | diego | Forfeit after moves | series-forfeit |

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -271,7 +271,8 @@ npx playwright test --grep-invert @scope:slow    # 느린 테스트 제외
 | yaroslava | ekaterina | Resting confirm | series-resting |
 | margarita | yevgeny | Resting timeout | series-resting |
 | yunel | idris | NoStart neither moves | series-nostart |
-| aleksandr | veer | NoStart second mover / timer | series-nostart |
+| aleksandr | veer | NoStart second mover | series-nostart |
+| monica | yun | NoStart timer delayed | series-nostart |
 | ramesh | nushi | Pool customize → Pick Phase | opening-pool-customize |
 | kwame | sonia | Selecting timeout → random | series-disconnect |
 | tomoko | renata | Resting both DC → abort | series-disconnect |

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -91,6 +91,9 @@ const users = [
   // Pair 30: akeem + rudra (Opening color mismatch bug)
   { username: 'akeem', password: 'password', file: '.auth/akeem.json' },
   { username: 'rudra', password: 'password', file: '.auth/rudra.json' },
+  // NoStart timer delayed (separate pair from NoStart second mover)
+  { username: 'monica', password: 'password', file: '.auth/monica.json' },
+  { username: 'yun', password: 'password', file: '.auth/yun.json' },
   // Solo: mateo (AI Opening Duel)
   { username: 'mateo', password: 'password', file: '.auth/mateo.json' },
 ];

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -96,6 +96,9 @@ export const users = {
   // Opening color mismatch bug (same opening, different colors)
   akeem: { username: 'akeem', password: 'password', storageState: '.auth/akeem.json' },
   rudra: { username: 'rudra', password: 'password', storageState: '.auth/rudra.json' },
+  // NoStart timer delayed (separate pair from NoStart second mover)
+  monica: { username: 'monica', password: 'password', storageState: '.auth/monica.json' },
+  yun: { username: 'yun', password: 'password', storageState: '.auth/yun.json' },
   // AI Opening Duel (vs Stockfish)
   mateo: { username: 'mateo', password: 'password', storageState: '.auth/mateo.json' },
 } as const;

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -9,94 +9,94 @@ export interface TestUser {
 // 테스트 계정 (lila-docker Full mode에서 생성됨)
 // storageState는 global-setup에서 생성됨
 export const users = {
-  // Pair 1: Happy path (pick confirm → ban confirm → game)
+  // Happy path (pick confirm → ban confirm → game)
   elena: { username: 'elena', password: 'password', storageState: '.auth/elena.json' },
   hans: { username: 'hans', password: 'password', storageState: '.auth/hans.json' },
-  // Pair 2: Pick OK → Ban timeout
+  // Pick OK → Ban timeout
   boris: { username: 'boris', password: 'password', storageState: '.auth/boris.json' },
   david: { username: 'david', password: 'password', storageState: '.auth/david.json' },
-  // Pair 3: Pick OK → Disconnect during ban
+  // Pick OK → Disconnect during ban
   yulia: { username: 'yulia', password: 'password', storageState: '.auth/yulia.json' },
   luis: { username: 'luis', password: 'password', storageState: '.auth/luis.json' },
-  // Pair 4: Pick timeout
+  // Pick timeout
   mei: { username: 'mei', password: 'password', storageState: '.auth/mei.json' },
   ivan: { username: 'ivan', password: 'password', storageState: '.auth/ivan.json' },
-  // Pair 5: Smoke tests (quick sanity checks)
+  // Smoke tests (quick sanity checks)
   ana: { username: 'ana', password: 'password', storageState: '.auth/ana.json' },
   lola: { username: 'lola', password: 'password', storageState: '.auth/lola.json' },
-  // Pair 6: Victory condition - 3-2 comeback
+  // Victory condition - 3-2 comeback
   carlos: { username: 'carlos', password: 'password', storageState: '.auth/carlos.json' },
   nina: { username: 'nina', password: 'password', storageState: '.auth/nina.json' },
-  // Pair 7: Victory condition - 2.5-0.5 early win
+  // Victory condition - 2.5-0.5 early win
   oscar: { username: 'oscar', password: 'password', storageState: '.auth/oscar.json' },
   petra: { username: 'petra', password: 'password', storageState: '.auth/petra.json' },
-  // Pair 8: Pick phase disconnect abort
+  // Pick phase disconnect abort
   angel: { username: 'angel', password: 'password', storageState: '.auth/angel.json' },
   bobby: { username: 'bobby', password: 'password', storageState: '.auth/bobby.json' },
-  // Pair 9: Ban phase disconnect abort
+  // Ban phase disconnect abort
   marcel: { username: 'marcel', password: 'password', storageState: '.auth/marcel.json' },
   vera: { username: 'vera', password: 'password', storageState: '.auth/vera.json' },
-  // Pair 10: Series forfeit during game (with moves)
+  // Series forfeit during game (with moves)
   fatima: { username: 'fatima', password: 'password', storageState: '.auth/fatima.json' },
   diego: { username: 'diego', password: 'password', storageState: '.auth/diego.json' },
-  // Pair 11: Series forfeit at game start (no moves)
+  // Series forfeit at game start (no moves)
   salma: { username: 'salma', password: 'password', storageState: '.auth/salma.json' },
   benjamin: { username: 'benjamin', password: 'password', storageState: '.auth/benjamin.json' },
-  // Pair 12: Finished page + rematch
+  // Finished page + rematch
   patricia: { username: 'patricia', password: 'password', storageState: '.auth/patricia.json' },
   adriana: { username: 'adriana', password: 'password', storageState: '.auth/adriana.json' },
-  // Pair 13: Countdown verification (pick/ban phase)
+  // Countdown verification (pick/ban phase)
   mary: { username: 'mary', password: 'password', storageState: '.auth/mary.json' },
   jose: { username: 'jose', password: 'password', storageState: '.auth/jose.json' },
-  // Pair 14: Countdown cancel behavior
+  // Countdown cancel behavior
   iryna: { username: 'iryna', password: 'password', storageState: '.auth/iryna.json' },
   pedro: { username: 'pedro', password: 'password', storageState: '.auth/pedro.json' },
-  // Pair 15: Disconnect during game → series forfeit
+  // Disconnect during game → series forfeit
   aaron: { username: 'aaron', password: 'password', storageState: '.auth/aaron.json' },
   jacob: { username: 'jacob', password: 'password', storageState: '.auth/jacob.json' },
-  // Pair 16: Disconnect during game 3 (after 0-2 score) → series forfeit
+  // Disconnect during game 3 (after 0-2 score) → series forfeit
   svetlana: { username: 'svetlana', password: 'password', storageState: '.auth/svetlana.json' },
   qing: { username: 'qing', password: 'password', storageState: '.auth/qing.json' },
-  // Pair 17: Pool exhaustion → series draw
+  // Pool exhaustion → series draw
   dmitry: { username: 'dmitry', password: 'password', storageState: '.auth/dmitry.json' },
   milena: { username: 'milena', password: 'password', storageState: '.auth/milena.json' },
-  // Pair 18: Resting phase - both confirm quickly
+  // Resting phase - both confirm quickly
   yaroslava: { username: 'yaroslava', password: 'password', storageState: '.auth/yaroslava.json' },
   ekaterina: { username: 'ekaterina', password: 'password', storageState: '.auth/ekaterina.json' },
-  // Pair 19: Resting phase - timeout (no confirm)
+  // Resting phase - timeout (no confirm)
   margarita: { username: 'margarita', password: 'password', storageState: '.auth/margarita.json' },
   yevgeny: { username: 'yevgeny', password: 'password', storageState: '.auth/yevgeny.json' },
-  // Pair 20: NoStart - white doesn't move
+  // NoStart - white doesn't move
   yunel: { username: 'yunel', password: 'password', storageState: '.auth/yunel.json' },
   idris: { username: 'idris', password: 'password', storageState: '.auth/idris.json' },
-  // Pair 21: NoStart - white moves, black doesn't
+  // NoStart - white moves, black doesn't
   aleksandr: { username: 'aleksandr', password: 'password', storageState: '.auth/aleksandr.json' },
   veer: { username: 'veer', password: 'password', storageState: '.auth/veer.json' },
-  // Pair 22: Pool customization → verify custom openings in pick phase
+  // Pool customization → verify custom openings in pick phase
   ramesh: { username: 'ramesh', password: 'password', storageState: '.auth/ramesh.json' },
   nushi: { username: 'nushi', password: 'password', storageState: '.auth/nushi.json' },
-  // Pair 23: Selecting timeout → random pick (loser doesn't select)
+  // Selecting timeout → random pick (loser doesn't select)
   kwame: { username: 'kwame', password: 'password', storageState: '.auth/kwame.json' },
   sonia: { username: 'sonia', password: 'password', storageState: '.auth/sonia.json' },
-  // Pair 24: Resting both DC → series abort
+  // Resting both DC → series abort
   tomoko: { username: 'tomoko', password: 'password', storageState: '.auth/tomoko.json' },
   renata: { username: 'renata', password: 'password', storageState: '.auth/renata.json' },
-  // Pair 25: Resting 1 DC → series forfeit
+  // Resting 1 DC → series forfeit
   yarah: { username: 'yarah', password: 'password', storageState: '.auth/yarah.json' },
   suresh: { username: 'suresh', password: 'password', storageState: '.auth/suresh.json' },
-  // Pair 26: Reconnection banner on home page
+  // Reconnection banner on home page
   frances: { username: 'frances', password: 'password', storageState: '.auth/frances.json' },
   emmanuel: { username: 'emmanuel', password: 'password', storageState: '.auth/emmanuel.json' },
-  // Pair 27: Lobby matching (Opening Duel with Anyone)
+  // Lobby matching (Opening Duel with Anyone)
   elizabeth: { username: 'elizabeth', password: 'password', storageState: '.auth/elizabeth.json' },
   dae: { username: 'dae', password: 'password', storageState: '.auth/dae.json' },
-  // Pair 29: Mobile viewport - Finished page scroll
+  // Mobile viewport - Finished page scroll
   gabriela: { username: 'gabriela', password: 'password', storageState: '.auth/gabriela.json' },
   guang: { username: 'guang', password: 'password', storageState: '.auth/guang.json' },
-  // Pair 30: Opening color mismatch bug (same opening, different colors)
+  // Opening color mismatch bug (same opening, different colors)
   akeem: { username: 'akeem', password: 'password', storageState: '.auth/akeem.json' },
   rudra: { username: 'rudra', password: 'password', storageState: '.auth/rudra.json' },
-  // Solo: AI Opening Duel (vs Stockfish)
+  // AI Opening Duel (vs Stockfish)
   mateo: { username: 'mateo', password: 'password', storageState: '.auth/mateo.json' },
 } as const;
 

--- a/tests/e2e/helpers/cleanup.ts
+++ b/tests/e2e/helpers/cleanup.ts
@@ -22,7 +22,7 @@ export function cleanupPairData(users: string[]): void {
       db.opening_pool.deleteMany({ "_id": { $in: ${JSON.stringify(users)} } });
     `.replace(/\n/g, ' ');
     execSync(
-      `docker exec chess-opening-duel-mongodb-1 mongosh lichess --quiet --eval '${mongoCommand}'`,
+      `docker exec app-mongodb-1 mongosh lichess --quiet --eval '${mongoCommand}'`,
       { encoding: 'utf-8', timeout: 10000 }
     );
   } catch {

--- a/tests/e2e/helpers/scenarios.ts
+++ b/tests/e2e/helpers/scenarios.ts
@@ -17,15 +17,15 @@ export interface TestScenario {
 /**
  * Test Scenario Matrix
  *
- * | # | P1 | P2 | pick-p1 | pick-p2 | ban-p1 | ban-p2 | series result (p1) |
- * |---|----|----|---------|---------|--------|--------|-------------------|
- * | 0 | elena | hans | confirm | confirm | confirm | confirm | 0 - 1/2 - 1 - 1 |
- * | 1 | yulia | luis | confirm | full-timeout | confirm | none-timeout | 1 - 1 - 1 |
- * | 2 | ana | lola | full-timeout | confirm | none-timeout | confirm | 0 - 1 - 0 - 1 - 1/2 - 1 |
- * | 3 | carlos | nina | partial-timeout | confirm | confirm | partial-timeout | 0 - 0 - 1 - 1 - 1 |
- * | 4 | oscar | petra | confirm | partial-timeout | partial-timeout | confirm | 1 - 1/2 - 1 |
- * | 5 | boris | david | none-timeout | confirm | confirm | full-timeout | 1 - 0 - 1 - 0 - 1/2 - 1 |
- * | 6 | mei | ivan | confirm | none-timeout | full-timeout | confirm | 0 - 1 - 1 - 1 |
+ * | P1 | P2 | pick-p1 | pick-p2 | ban-p1 | ban-p2 | series result (p1) |
+ * |----|----|----|---------|---------|--------|--------|-------------------|
+ * | elena | hans | confirm | confirm | confirm | confirm | 0 - 1/2 - 1 - 1 |
+ * | yulia | luis | confirm | full-timeout | confirm | none-timeout | 1 - 1 - 1 |
+ * | ana | lola | full-timeout | confirm | none-timeout | confirm | 0 - 1 - 0 - 1 - 1/2 - 1 |
+ * | carlos | nina | partial-timeout | confirm | confirm | partial-timeout | 0 - 0 - 1 - 1 - 1 |
+ * | oscar | petra | confirm | partial-timeout | partial-timeout | confirm | 1 - 1/2 - 1 |
+ * | boris | david | none-timeout | confirm | confirm | full-timeout | 1 - 0 - 1 - 0 - 1/2 - 1 |
+ * | mei | ivan | confirm | none-timeout | full-timeout | confirm | 0 - 1 - 1 - 1 |
  */
 export const testScenarios: TestScenario[] = [
   {

--- a/tests/e2e/helpers/series.ts
+++ b/tests/e2e/helpers/series.ts
@@ -519,7 +519,7 @@ export async function createSeriesChallenge(
     // The dropdown items have class "complete-result" and are <span> elements
     // See: repos/lila/ui/lib/src/view/userComplete.ts (renderUserEntry)
     // See: repos/lila/ui/bits/src/bits.challengePage.ts (tag: 'span')
-    const dropdownItem = player1.locator('.complete-result').filter({ hasText: new RegExp(player2Username, 'i') });
+    const dropdownItem = player1.locator('.complete-result').filter({ hasText: new RegExp(`^${player2Username}$`, 'i') });
     await expect(dropdownItem.first()).toBeVisible({ timeout: 3000 });
     await dropdownItem.first().click();
 

--- a/tests/e2e/specs/opening-pool-customize.spec.ts
+++ b/tests/e2e/specs/opening-pool-customize.spec.ts
@@ -71,7 +71,7 @@ function makeScreenshot(testInfo: typeof test) {
   };
 }
 
-test.describe('Pool Customize → Pick Phase Verification', () => {
+test.describe('Pool Customize → Pick Phase Verification @phase:pick @phase:ban @feature:pool @scope:quick', () => {
   test.beforeAll(() => {
     cleanupPairData(pairUsers);
   });

--- a/tests/e2e/specs/opening-pool-customize.spec.ts
+++ b/tests/e2e/specs/opening-pool-customize.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../helpers/series';
 
 /**
- * Test 23: Opening Pool Customize → Pick Phase 검증
+ * Opening Pool Customize → Pick Phase 검증
  *
  * 시나리오:
  * 1. P1(ramesh)이 기본 pool에서 5개 오프닝을 X 버튼으로 삭제
@@ -71,12 +71,12 @@ function makeScreenshot(testInfo: typeof test) {
   };
 }
 
-test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
+test.describe('Pool Customize → Pick Phase Verification', () => {
   test.beforeAll(() => {
     cleanupPairData(pairUsers);
   });
 
-  test('[Test 23] 커스텀 pool로 시리즈 생성 시 Pick Phase에 새 오프닝 표시', async ({ browser }) => {
+  test('커스텀 pool로 시리즈 생성 시 Pick Phase에 새 오프닝 표시', async ({ browser }) => {
     test.setTimeout(120_000);
     const screenshot = makeScreenshot(test);
     const { player1Context, player2Context, player1, player2 } =
@@ -127,7 +127,7 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
           const text = await nameLinks.nth(i).textContent();
           if (text) remainingNames.push(text.trim());
         }
-        console.log('[Test 23] Remaining pool openings:', remainingNames);
+        console.log('[Pool Customize] Remaining pool openings:', remainingNames);
       });
 
       // ===== Step 2.5: 승률 불균형 오프닝(Bongcloud) 추가 차단 검증 =====
@@ -152,13 +152,13 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
           // tooltip 확인: "Win rate too imbalanced" 포함
           const whiteTitle = await whiteBtn.getAttribute('title');
           expect(whiteTitle).toContain('Win rate too imbalanced');
-          console.log(`[Test 23] ✓ Imbalanced tooltip: "${whiteTitle}"`);
+          console.log(`[Pool Customize] ✓ Imbalanced tooltip: "${whiteTitle}"`);
 
-          console.log('[Test 23] ✓ Bongcloud buttons disabled (win rate imbalanced)');
+          console.log('[Pool Customize] ✓ Bongcloud buttons disabled (win rate imbalanced)');
           await screenshot('02.5-bongcloud-blocked', player1);
         } else {
           // exactOpening이 아니면 버튼 자체가 없을 수 있음
-          console.log('[Test 23] ✓ Bongcloud has no add buttons (not exactOpening)');
+          console.log('[Pool Customize] ✓ Bongcloud has no add buttons (not exactOpening)');
         }
       });
 
@@ -185,10 +185,10 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
             addedNames.push(opening.name);
             await screenshot(`03-added-${opening.name.replace(/\s+/g, '-')}`, player1);
           } else {
-            console.log(`[Test 23] Warning: Add button not visible for ${opening.name} at ${opening.url}`);
+            console.log(`[Pool Customize] Warning: Add button not visible for ${opening.name} at ${opening.url}`);
           }
         }
-        console.log('[Test 23] Added openings:', addedNames);
+        console.log('[Pool Customize] Added openings:', addedNames);
         expect(addedNames.length).toBeGreaterThanOrEqual(3); // 최소 3개는 추가되어야 함
       });
 
@@ -215,7 +215,7 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
         await expect(btn).toBeDisabled();
         const titleText = await btn.getAttribute('title');
         expect(titleText).toBe('Already in your pool');
-        console.log(`[Test 23] ✓ "Already in your pool" tooltip on ${firstAdded.name} (${firstAdded.color})`);
+        console.log(`[Pool Customize] ✓ "Already in your pool" tooltip on ${firstAdded.name} (${firstAdded.color})`);
         await screenshot('04.5-already-in-pool-tooltip', player1);
       });
 
@@ -231,10 +231,10 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
           await expect(btn).toBeDisabled();
           const titleText = await btn.getAttribute('title');
           expect(titleText).toBe('Pool is full (10/10)');
-          console.log(`[Test 23] ✓ "Pool is full (10/10)" tooltip on ${notInPool.name}`);
+          console.log(`[Pool Customize] ✓ "Pool is full (10/10)" tooltip on ${notInPool.name}`);
           await screenshot('04.6-pool-full-tooltip', player1);
         } else {
-          console.log(`[Test 23] ✓ ${notInPool.name} has no add buttons (not exactOpening)`);
+          console.log(`[Pool Customize] ✓ ${notInPool.name} has no add buttons (not exactOpening)`);
         }
       });
 
@@ -243,7 +243,7 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
       await test.step('P1 & P2: Opening Duel 생성', async () => {
         await loginBothPlayers(player1, player2, p1User, p2User);
         seriesId = await createSeriesChallenge(player1, player2, p2Username);
-        console.log(`[Test 23] Series created: ${seriesId}`);
+        console.log(`[Pool Customize] Series created: ${seriesId}`);
       });
 
       // ===== Step 5: Pick Phase에서 오프닝 이름 검증 =====
@@ -260,14 +260,14 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
           const text = await openingNameEls.nth(i).textContent();
           if (text) pickPhaseNames.push(text.trim());
         }
-        console.log('[Test 23] Pick phase openings:', pickPhaseNames);
+        console.log('[Pool Customize] Pick phase openings:', pickPhaseNames);
         expect(pickPhaseNames.length).toBe(10);
 
         // 새로 추가한 오프닝이 Pick Phase에 포함되는지 확인
         for (const name of addedNames) {
           const found = pickPhaseNames.some(n => n.includes(name) || name.includes(n));
           expect(found).toBeTruthy();
-          console.log(`[Test 23] ✓ Found "${name}" in pick phase`);
+          console.log(`[Pool Customize] ✓ Found "${name}" in pick phase`);
         }
 
         // 삭제한 오프닝이 Pick Phase에 없는지 확인
@@ -276,10 +276,10 @@ test.describe('Test 23: Pool Customize → Pick Phase Verification', () => {
         for (const name of removedNames) {
           const found = pickPhaseNames.some(n => n === name);
           if (found) {
-            console.log(`[Test 23] ✗ Removed opening "${name}" still found in pick phase!`);
+            console.log(`[Pool Customize] ✗ Removed opening "${name}" still found in pick phase!`);
           }
           expect(found).toBeFalsy();
-          console.log(`[Test 23] ✓ Removed opening "${name}" not in pick phase`);
+          console.log(`[Pool Customize] ✓ Removed opening "${name}" not in pick phase`);
         }
 
         await screenshot('06-pick-phase-verified', player1);

--- a/tests/e2e/specs/opening-pool.spec.ts
+++ b/tests/e2e/specs/opening-pool.spec.ts
@@ -4,7 +4,7 @@ import { users } from '../helpers/auth';
 const user = users.elena;
 
 test.describe('Opening Pool Page', () => {
-  test('[Test 20] Opening Pool 페이지 접근 및 렌더링 확인', async ({ browser }) => {
+  test('Opening Pool 페이지 접근 및 렌더링 확인', async ({ browser }) => {
     const context = await browser.newContext({ storageState: user.storageState });
     const page = await context.newPage();
 
@@ -42,7 +42,7 @@ test.describe('Opening Pool Page', () => {
     }
   });
 
-  test('[Test 20] 비로그인 상태에서 /opening-pool 접근 시 리다이렉트', async ({ browser }) => {
+  test('비로그인 상태에서 /opening-pool 접근 시 리다이렉트', async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
 
@@ -58,7 +58,7 @@ test.describe('Opening Pool Page', () => {
 });
 
 test.describe('Opening Pool Table on all opening pages', () => {
-  test('[Test 21] 로그인 시 모든 opening 페이지에 pool 테이블 표시', async ({ browser }) => {
+  test('로그인 시 모든 opening 페이지에 pool 테이블 표시', async ({ browser }) => {
     const context = await browser.newContext({ storageState: user.storageState });
     const page = await context.newPage();
 
@@ -132,7 +132,7 @@ test.describe('Opening Pool Table on all opening pages', () => {
     }
   });
 
-  test('[Test 21] 비로그인 시 opening 페이지에 pool 테이블 미표시', async ({ browser }) => {
+  test('비로그인 시 opening 페이지에 pool 테이블 미표시', async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
 

--- a/tests/e2e/specs/opening-pool.spec.ts
+++ b/tests/e2e/specs/opening-pool.spec.ts
@@ -3,7 +3,7 @@ import { users } from '../helpers/auth';
 
 const user = users.elena;
 
-test.describe('Opening Pool Page', () => {
+test.describe('Opening Pool Page @feature:pool @scope:quick', () => {
   test('Opening Pool 페이지 접근 및 렌더링 확인', async ({ browser }) => {
     const context = await browser.newContext({ storageState: user.storageState });
     const page = await context.newPage();
@@ -57,7 +57,7 @@ test.describe('Opening Pool Page', () => {
   });
 });
 
-test.describe('Opening Pool Table on all opening pages', () => {
+test.describe('Opening Pool Table on all opening pages @feature:pool @scope:quick', () => {
   test('로그인 시 모든 opening 페이지에 pool 테이블 표시', async ({ browser }) => {
     const context = await browser.newContext({ storageState: user.storageState });
     const page = await context.newPage();

--- a/tests/e2e/specs/series-ai.spec.ts
+++ b/tests/e2e/specs/series-ai.spec.ts
@@ -35,7 +35,7 @@ import {
  * | mateo | Solo vs Stockfish level 1, verify AI move, then forfeit |
  */
 
-test.describe('AI Opening Duel: mateo vs Stockfish', () => {
+test.describe('AI Opening Duel: mateo vs Stockfish @phase:pick @phase:ban @phase:game @feature:ai @scope:slow', () => {
   test.describe.configure({ timeout: 180000 });
 
   const testUsers = ['mateo'];

--- a/tests/e2e/specs/series-banpick.spec.ts
+++ b/tests/e2e/specs/series-banpick.spec.ts
@@ -17,15 +17,15 @@ import {
  *
  * Test Scenario Matrix:
  *
- * | # | P1 | P2 | pick-p1 | pick-p2 | ban-p1 | ban-p2 | series result (p1) |
- * |---|----|----|---------|---------|--------|--------|-------------------|
- * | 0 | elena | hans | confirm | confirm | confirm | confirm | 0 - 1/2 - 1 - 1 |
- * | 1 | yulia | luis | confirm | full-timeout | confirm | none-timeout | 1 - 1 - 1 |
- * | 2 | ana | lola | full-timeout | confirm | none-timeout | confirm | 0 - 1 - 0 - 1 - 1/2 - 1 |
- * | 3 | carlos | nina | partial-timeout | confirm | confirm | partial-timeout | 0 - 0 - 1 - 1 - 1 |
- * | 4 | oscar | petra | confirm | partial-timeout | partial-timeout | confirm | 1 - 1/2 - 1 |
- * | 5 | boris | david | none-timeout | confirm | confirm | full-timeout | 1 - 0 - 1 - 0 - 1/2 - 1 |
- * | 6 | mei | ivan | confirm | none-timeout | full-timeout | confirm | 0 - 1 - 1 - 1 |
+ * | P1 | P2 | pick-p1 | pick-p2 | ban-p1 | ban-p2 | series result (p1) |
+ * |----|----|----|---------|---------|--------|--------|-------------------|
+ * | elena | hans | confirm | confirm | confirm | confirm | 0 - 1/2 - 1 - 1 |
+ * | yulia | luis | confirm | full-timeout | confirm | none-timeout | 1 - 1 - 1 |
+ * | ana | lola | full-timeout | confirm | none-timeout | confirm | 0 - 1 - 0 - 1 - 1/2 - 1 |
+ * | carlos | nina | partial-timeout | confirm | confirm | partial-timeout | 0 - 0 - 1 - 1 - 1 |
+ * | oscar | petra | confirm | partial-timeout | partial-timeout | confirm | 1 - 1/2 - 1 |
+ * | boris | david | none-timeout | confirm | confirm | full-timeout | 1 - 0 - 1 - 0 - 1/2 - 1 |
+ * | mei | ivan | confirm | none-timeout | full-timeout | confirm | 0 - 1 - 1 - 1 |
  *
  * Pick/Ban Behaviors:
  * - confirm: Select required amount and confirm button
@@ -71,17 +71,17 @@ function calculateTimeout(
 
 // Generate tests from scenario matrix
 for (const scenario of testScenarios) {
-  const { id, player1: p1User, player2: p2User, pick, ban, seriesResult, description } = scenario;
+  const { player1: p1User, player2: p2User, pick, ban, seriesResult, description } = scenario;
   const pairUsers = [p1User.username, p2User.username];
 
   const timeout = calculateTimeout(seriesResult, pick, ban);
 
-  test.describe(`Test ${id}: ${p1User.username} vs ${p2User.username}`, () => {
+  test.describe(`${p1User.username} vs ${p2User.username}: ${description}`, () => {
     test.describe.configure({ timeout });
 
     test.beforeAll(() => cleanupPairData(pairUsers));
 
-    test(`[Test ${id}] ${description}`, async ({ browser }) => {
+    test(description, async ({ browser }) => {
       const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
         browser,
         p1User,

--- a/tests/e2e/specs/series-color-mismatch.spec.ts
+++ b/tests/e2e/specs/series-color-mismatch.spec.ts
@@ -120,7 +120,7 @@ function makeScreenshot(testInfo: typeof test) {
   };
 }
 
-test.describe('Opening Color Mismatch Bug (#101)', () => {
+test.describe('Opening Color Mismatch Bug (#101) @phase:pick @phase:ban @phase:game @feature:pool @scope:quick', () => {
   test.beforeAll(() => {
     cleanupPairData(pairUsers);
   });

--- a/tests/e2e/specs/series-color-mismatch.spec.ts
+++ b/tests/e2e/specs/series-color-mismatch.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '../helpers/series';
 
 /**
- * Test 30: Opening Color Mismatch Bug (GitHub Issue #101)
+ * Opening Color Mismatch Bug (GitHub Issue #101)
  *
  * 재현 시나리오:
  * 1. P1(akeem)의 풀에 Najdorf 서브변형 5종을 white/black 양쪽으로 등록 (총 10칸)
@@ -120,12 +120,12 @@ function makeScreenshot(testInfo: typeof test) {
   };
 }
 
-test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
+test.describe('Opening Color Mismatch Bug (#101)', () => {
   test.beforeAll(() => {
     cleanupPairData(pairUsers);
   });
 
-  test('[Test 30] 같은 오프닝 white/black 혼재 시 올바른 색상 배정', async ({ browser }) => {
+  test('같은 오프닝 white/black 혼재 시 올바른 색상 배정', async ({ browser }) => {
     test.setTimeout(180_000);
     const screenshot = makeScreenshot(test);
     const { player1Context, player2Context, player1, player2 } =
@@ -157,9 +157,9 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
             `docker exec app-mongodb-1 mongosh lichess --quiet --file /tmp/test30-mongo.js`,
             { encoding: 'utf-8', timeout: 10000 },
           );
-          console.log('[Test 30] Pool set via MongoDB (Najdorf 5종 × white/black = 10)');
+          console.log('[Color Mismatch] Pool set via MongoDB (Najdorf 5종 × white/black = 10)');
         } catch (e) {
-          console.error('[Test 30] MongoDB pool setup failed:', e);
+          console.error('[Color Mismatch] MongoDB pool setup failed:', e);
           throw e;
         }
 
@@ -176,7 +176,7 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
       await test.step('시리즈 생성', async () => {
         await loginBothPlayers(player1, player2, p1User, p2User);
         seriesId = await createSeriesChallenge(player1, player2, p2Username);
-        console.log(`[Test 30] Series created: ${seriesId}`);
+        console.log(`[Color Mismatch] Series created: ${seriesId}`);
       });
 
       // ===== Step 3: P1이 black 오프닝만 5개 선택 =====
@@ -189,7 +189,7 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
           `${selectors.opening}.owner-black:not(.selected):not(.disabled)`,
         );
         const blackCount = await blackOpenings.count();
-        console.log(`[Test 30] Available black openings: ${blackCount}`);
+        console.log(`[Color Mismatch] Available black openings: ${blackCount}`);
         expect(blackCount).toBe(5);
 
         for (let i = 0; i < 5; i++) {
@@ -207,7 +207,7 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
           .locator(`${selectors.openingSelected}.owner-black`)
           .count();
         expect(selectedBlack).toBe(5);
-        console.log('[Test 30] Selected 5 black openings (white counterparts exist in pool)');
+        console.log('[Color Mismatch] Selected 5 black openings (white counterparts exist in pool)');
 
         await screenshot('p1-picked-black-only', player1);
         await confirm(player1);
@@ -267,7 +267,7 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
           await player1.waitForTimeout(1000);
         }
         expect(gameId).toBeTruthy();
-        console.log(`[Test 30] Game started: ${gameId}`);
+        console.log(`[Color Mismatch] Game started: ${gameId}`);
 
         // Series API에서 사용된 오프닝의 ownerColor 확인
         const seriesResponse = await player1.request.get(
@@ -285,14 +285,14 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
         );
 
         console.log(
-          `[Test 30] Used opening: "${usedOpening?.name}", ownerColor: ${usedOpening?.ownerColor}, owner: ${usedOpening?.owner}, p1Index: ${p1Index}`,
+          `[Color Mismatch] Used opening: "${usedOpening?.name}", ownerColor: ${usedOpening?.ownerColor}, owner: ${usedOpening?.owner}, p1Index: ${p1Index}`,
         );
 
         // 핵심 검증: P1이 픽한 오프닝이면 ownerColor가 반드시 black이어야 함
         // (버그 상태: find(_.name == name)이 같은 이름의 white를 먼저 반환 → ownerColor가 white)
         if (usedOpening?.owner === p1Index) {
           expect(usedOpening.ownerColor).toBe('black');
-          console.log('[Test 30] ✓ P1 opening ownerColor is correctly "black" (not "white")');
+          console.log('[Color Mismatch] ✓ P1 opening ownerColor is correctly "black" (not "white")');
         }
 
         // Game Export API로 실제 게임 색상 확인
@@ -301,13 +301,13 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
 
         const gameState = await getGameState(player1, gameId!);
         console.log(
-          `[Test 30] Game colors — White: ${gameState.whitePlayer}, Black: ${gameState.blackPlayer}`,
+          `[Color Mismatch] Game colors — White: ${gameState.whitePlayer}, Black: ${gameState.blackPlayer}`,
         );
 
         // P1의 오프닝이 사용됐으면, P1은 black을 맡아야 함
         if (usedOpening?.owner === p1Index) {
           expect(gameState.blackPlayer).toBe(p1Username.toLowerCase());
-          console.log(`[Test 30] ✓ P1(${p1Username}) is correctly playing BLACK`);
+          console.log(`[Color Mismatch] ✓ P1(${p1Username}) is correctly playing BLACK`);
         }
 
         // chessground orientation 확인
@@ -317,7 +317,7 @@ test.describe('Test 30: Opening Color Mismatch Bug (#101)', () => {
           el.classList.contains('orientation-white'),
         );
         const p1Color = isWhiteOrientation ? 'white' : 'black';
-        console.log(`[Test 30] P1 board orientation: ${p1Color}`);
+        console.log(`[Color Mismatch] P1 board orientation: ${p1Color}`);
 
         if (gameState.whitePlayer === p1Username.toLowerCase()) {
           expect(isWhiteOrientation).toBe(true);

--- a/tests/e2e/specs/series-countdown.spec.ts
+++ b/tests/e2e/specs/series-countdown.spec.ts
@@ -30,7 +30,7 @@ import { verifyOpeningsTab } from '../helpers/openings-tab';
  * iryna vs pedro: Countdown cancel + re-confirm behavior
  */
 
-test.describe('mary vs jose: Countdown appears in pick/ban phases', () => {
+test.describe('mary vs jose: Countdown appears in pick/ban phases @phase:pick @phase:ban @feature:countdown @scope:quick', () => {
   test.describe.configure({ timeout: 90000 });
 
   const pairUsers = ['mary', 'jose'];
@@ -165,7 +165,7 @@ test.describe('mary vs jose: Countdown appears in pick/ban phases', () => {
   });
 });
 
-test.describe('iryna vs pedro: Countdown cancel + re-confirm', () => {
+test.describe('iryna vs pedro: Countdown cancel + re-confirm @phase:pick @phase:ban @feature:countdown @scope:quick', () => {
   test.describe.configure({ timeout: 90000 });
 
   const pairUsers = ['iryna', 'pedro'];

--- a/tests/e2e/specs/series-countdown.spec.ts
+++ b/tests/e2e/specs/series-countdown.spec.ts
@@ -26,12 +26,11 @@ import { verifyOpeningsTab } from '../helpers/openings-tab';
  * Tests the 3-second countdown timer that appears after both players confirm
  * in pick/ban phases, and when the selecting player confirms.
  *
- * Test 1 (mary vs jose): Countdown appears and decrements in pick/ban phases
- * Test 2 (iryna vs pedro): Countdown cancel + re-confirm behavior
+ * mary vs jose: Countdown appears and decrements in pick/ban phases
+ * iryna vs pedro: Countdown cancel + re-confirm behavior
  */
 
-// ===== Test 1: Countdown appears and decrements =====
-test.describe('Test 1: Countdown appears in pick/ban phases (mary vs jose)', () => {
+test.describe('mary vs jose: Countdown appears in pick/ban phases', () => {
   test.describe.configure({ timeout: 90000 });
 
   const pairUsers = ['mary', 'jose'];
@@ -166,8 +165,7 @@ test.describe('Test 1: Countdown appears in pick/ban phases (mary vs jose)', () 
   });
 });
 
-// ===== Test 2: Countdown cancel behavior =====
-test.describe('Test 2: Countdown cancel + re-confirm (iryna vs pedro)', () => {
+test.describe('iryna vs pedro: Countdown cancel + re-confirm', () => {
   test.describe.configure({ timeout: 90000 });
 
   const pairUsers = ['iryna', 'pedro'];

--- a/tests/e2e/specs/series-disconnect.spec.ts
+++ b/tests/e2e/specs/series-disconnect.spec.ts
@@ -50,7 +50,7 @@ test.describe('angel vs bobby: Pick disconnect', () => {
   const pairUsers = ['angel', 'bobby'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('Pick phase disconnect → abort', async ({ browser }) => {
+  test('Pick phase disconnect → abort @phase:pick @feature:disconnect @scope:quick', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.angel,
@@ -135,7 +135,7 @@ test.describe('marcel vs vera: Ban disconnect', () => {
   const pairUsers = ['marcel', 'vera'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('Ban phase disconnect → abort', async ({ browser }) => {
+  test('Ban phase disconnect → abort @phase:pick @phase:ban @feature:disconnect @scope:quick', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.marcel,
@@ -238,7 +238,7 @@ test.describe('aaron vs jacob: Game disconnect → game loss', () => {
   const pairUsers = ['aaron', 'jacob'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('Game disconnect → game loss, series continues', async ({ browser }) => {
+  test('Game disconnect → game loss, series continues @phase:pick @phase:ban @phase:game @feature:disconnect @scope:quick', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.aaron,
@@ -356,7 +356,7 @@ test.describe('svetlana vs qing: 0-2 then game 3 disconnect → game loss', () =
   const pairUsers = ['svetlana', 'qing'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('0-2 then game 3 disconnect → game loss (score 1-2), series continues', async ({ browser }) => {
+  test('0-2 then game 3 disconnect → game loss (score 1-2), series continues @phase:pick @phase:ban @phase:game @feature:disconnect @scope:slow', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.svetlana,
@@ -498,7 +498,7 @@ test.describe('kwame vs sonia: Selecting timeout → random pick', () => {
   const pairUsers = ['kwame', 'sonia'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('Selecting timeout → random pick, game 2 starts', async ({ browser }) => {
+  test('Selecting timeout → random pick, game 2 starts @phase:pick @phase:ban @phase:game @phase:selecting @feature:disconnect @scope:slow', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.kwame,
@@ -603,7 +603,7 @@ test.describe('tomoko vs renata: Resting both DC → abort', () => {
   const pairUsers = ['tomoko', 'renata'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('Resting both DC → series abort', async ({ browser }) => {
+  test('Resting both DC → series abort @phase:pick @phase:ban @phase:game @phase:resting @feature:disconnect @scope:quick', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.tomoko,
@@ -706,7 +706,7 @@ test.describe('yarah vs suresh: Resting 1 DC → forfeit', () => {
   const pairUsers = ['yarah', 'suresh'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('Resting 1 DC → series forfeit (P1 wins)', async ({ browser }) => {
+  test('Resting 1 DC → series forfeit (P1 wins) @phase:pick @phase:ban @phase:game @phase:resting @feature:disconnect @scope:quick', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.yarah,

--- a/tests/e2e/specs/series-disconnect.spec.ts
+++ b/tests/e2e/specs/series-disconnect.spec.ts
@@ -32,26 +32,25 @@ import {
  * - Playing phase: DC → game loss only, series continues (not forfeit)
  * - Resting phase: 1 DC → forfeit, both DC → abort
  *
- * | # | P1 | P2 | Phase | Disconnect | Expected |
- * |---|----|----|-------|------------|----------|
- * | 7 | angel | bobby | Pick | P2 disconnects after P1 confirms | Series aborted |
- * | 8 | marcel | vera | Ban | P2 disconnects after P1 confirms | Series aborted |
- * | 14 | aaron | jacob | Playing | P2 disconnects during game 1 | Game loss (P1 wins game), series continues |
- * | 15 | svetlana | qing | Playing | P2 disconnects during game 3 (score 0-2) | Game loss (score 1-2), series continues |
- * | 21 | kwame | sonia | Selecting | Loser doesn't select, timeout fires | Random pick, game 2 starts |
- * | 22 | tomoko | renata | Resting | Both players disconnect during Resting | Series aborted |
- * | 23 | yarah | suresh | Resting | P2 disconnects during Resting, P1 stays | Series forfeit (P1 wins) |
+ * | P1 | P2 | Phase | Disconnect | Expected |
+ * |----|-------|------------|----------|----------|
+ * | angel | bobby | Pick | P2 disconnects after P1 confirms | Series aborted |
+ * | marcel | vera | Ban | P2 disconnects after P1 confirms | Series aborted |
+ * | aaron | jacob | Playing | P2 disconnects during game 1 | Game loss (P1 wins game), series continues |
+ * | svetlana | qing | Playing | P2 disconnects during game 3 (score 0-2) | Game loss (score 1-2), series continues |
+ * | kwame | sonia | Selecting | Loser doesn't select, timeout fires | Random pick, game 2 starts |
+ * | tomoko | renata | Resting | Both players disconnect during Resting | Series aborted |
+ * | yarah | suresh | Resting | P2 disconnects during Resting, P1 stays | Series forfeit (P1 wins) |
  */
 
-// ===== Test 7: Pick Phase Disconnect =====
-test.describe('Test 7: angel vs bobby (Pick disconnect)', () => {
+test.describe('angel vs bobby: Pick disconnect', () => {
   // 30s phase timeout + buffer
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['angel', 'bobby'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 7] Pick phase disconnect → abort', async ({ browser }) => {
+  test('Pick phase disconnect → abort', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.angel,
@@ -101,7 +100,7 @@ test.describe('Test 7: angel vs bobby (Pick disconnect)', () => {
         await takeScreenshot('p2-before-disconnect', player2);
 
         // P2: close page (WebSocket disconnects)
-        console.log('[Test 7] Closing P2 page to simulate disconnect...');
+        console.log('[Pick DC] Closing P2 page to simulate disconnect...');
         await player2.close();
         await takeScreenshot('p1-after-p2-disconnect', player1);
       });
@@ -114,13 +113,13 @@ test.describe('Test 7: angel vs bobby (Pick disconnect)', () => {
         // Wait for series to be aborted
         // Phase timeout = 30s, disconnect detection = ~5s, server processing = ~2s
         // 25 retries × 2s interval = 50s total (covers 30s timeout + margin)
-        console.log('[Test 7] Waiting for phase timeout and abort...');
+        console.log('[Pick DC] Waiting for phase timeout and abort...');
         const aborted = await isSeriesAborted(player1, seriesId, 25);
 
         await takeScreenshot('after-abort', player1);
 
         expect(aborted).toBe(true);
-        console.log(`[Test 7] Series ${seriesId} aborted successfully`);
+        console.log(`[Pick DC] Series ${seriesId} aborted successfully`);
       });
     } finally {
       await player1Context.close();
@@ -129,15 +128,14 @@ test.describe('Test 7: angel vs bobby (Pick disconnect)', () => {
   });
 });
 
-// ===== Test 8: Ban Phase Disconnect =====
-test.describe('Test 8: marcel vs vera (Ban disconnect)', () => {
+test.describe('marcel vs vera: Ban disconnect', () => {
   // Pick confirm + 30s ban timeout + buffer
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['marcel', 'vera'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 8] Ban phase disconnect → abort', async ({ browser }) => {
+  test('Ban phase disconnect → abort', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.marcel,
@@ -207,7 +205,7 @@ test.describe('Test 8: marcel vs vera (Ban disconnect)', () => {
         await takeScreenshot('p2-before-disconnect', player2);
 
         // P2: close page (WebSocket disconnects)
-        console.log('[Test 8] Closing P2 page to simulate disconnect...');
+        console.log('[Ban DC] Closing P2 page to simulate disconnect...');
         await player2.close();
         await takeScreenshot('p1-after-p2-disconnect', player1);
       });
@@ -218,13 +216,13 @@ test.describe('Test 8: marcel vs vera (Ban disconnect)', () => {
         player1.on('dialog', dialog => dialog.dismiss());
 
         // Wait for series to be aborted
-        console.log('[Test 8] Waiting for phase timeout and abort...');
+        console.log('[Ban DC] Waiting for phase timeout and abort...');
         const aborted = await isSeriesAborted(player1, seriesId, 20);
 
         await takeScreenshot('after-abort', player1);
 
         expect(aborted).toBe(true);
-        console.log(`[Test 8] Series ${seriesId} aborted successfully`);
+        console.log(`[Ban DC] Series ${seriesId} aborted successfully`);
       });
     } finally {
       await player1Context.close();
@@ -233,15 +231,14 @@ test.describe('Test 8: marcel vs vera (Ban disconnect)', () => {
   });
 });
 
-// ===== Test 14: Disconnect During Game → Game Loss (series continues) =====
-test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
+test.describe('aaron vs jacob: Game disconnect → game loss', () => {
   // Ban/pick ~30s + game disconnect detection ~90s + buffer
   test.describe.configure({ timeout: 180000 });
 
   const pairUsers = ['aaron', 'jacob'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 14] Game disconnect → game loss, series continues', async ({ browser }) => {
+  test('Game disconnect → game loss, series continues', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.aaron,
@@ -285,7 +282,7 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
 
       // Step 4: P2 disconnects (close page)
       await test.step('P2 (jacob) disconnects during game', async () => {
-        console.log('[Test 14] Closing P2 page to simulate disconnect during game...');
+        console.log('[Game DC] Closing P2 page to simulate disconnect during game...');
         await player2.close();
         await takeScreenshot('p1-after-p2-disconnect', player1);
 
@@ -294,11 +291,11 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
         // If it's P1's turn, make one more move to pass turn to disconnected P2.
         const myTurn = await isMyTurn(player1, 'aaron');
         if (myTurn) {
-          console.log('[Test 14] P1 makes extra move to pass turn to disconnected P2...');
+          console.log('[Game DC] P1 makes extra move to pass turn to disconnected P2...');
           await makeAnyMove(player1, 'aaron');
           await takeScreenshot('p1-extra-move', player1);
         } else {
-          console.log('[Test 14] Already P2 turn, no extra move needed');
+          console.log('[Game DC] Already P2 turn, no extra move needed');
         }
       });
 
@@ -306,7 +303,7 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
       await test.step('P1 claims victory after disconnect timeout', async () => {
         // The server detects disconnect after ~60s (blitz: 30s base * 2 multiplier).
         // The "Claim victory" button appears in div.suggestion when opponent is "long gone".
-        console.log('[Test 14] Waiting for "Claim victory" button (~60s)...');
+        console.log('[Game DC] Waiting for "Claim victory" button (~60s)...');
 
         const forceResignBtn = player1.locator('div.suggestion button.button').first();
         await expect(forceResignBtn).toBeVisible({ timeout: 120000 });
@@ -315,7 +312,7 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
 
         // Click "Force resignation" → triggers rageQuit → Status.Timeout
         await forceResignBtn.click();
-        console.log('[Test 14] Clicked "Force resignation"');
+        console.log('[Game DC] Clicked "Force resignation"');
 
         await player1.waitForTimeout(2000);
         await takeScreenshot('after-force-resign', player1);
@@ -327,7 +324,7 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
         await player1.waitForTimeout(3000);
 
         const data = await getSeriesData(player1, seriesId);
-        console.log(`[Test 14] Series data: ${JSON.stringify(data)}`);
+        console.log(`[Game DC] Series data: ${JSON.stringify(data)}`);
 
         expect(data).not.toBeNull();
         // status=20 (Started), NOT 30 (Finished) or 40 (Aborted)
@@ -343,7 +340,7 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
         expect(totalScore).toBe(1); // exactly 1 game result recorded
 
         await takeScreenshot('series-continues', player1);
-        console.log(`[Test 14] Series continues with scores: ${data!.scores[0]}-${data!.scores[1]}`);
+        console.log(`[Game DC] Series continues with scores: ${data!.scores[0]}-${data!.scores[1]}`);
       });
     } finally {
       await player1Context.close();
@@ -352,15 +349,14 @@ test.describe('Test 14: aaron vs jacob (Game disconnect → game loss)', () => {
   });
 });
 
-// ===== Test 15: Disconnect During Game 3 After 0-2 Score → Game Loss (series continues) =====
-test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game loss)', () => {
+test.describe('svetlana vs qing: 0-2 then game 3 disconnect → game loss', () => {
   // 2 games + resting phases + selecting phases + disconnect detection ~60s + buffer
   test.describe.configure({ timeout: 260000 });
 
   const pairUsers = ['svetlana', 'qing'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 15] 0-2 then game 3 disconnect → game loss (score 1-2), series continues', async ({ browser }) => {
+  test('0-2 then game 3 disconnect → game loss (score 1-2), series continues', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.svetlana,
@@ -396,7 +392,7 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
       let game1Id = '';
       await test.step('Game 1: P1 resigns (0-1)', async () => {
         game1Id = await playOneGame(player1, player2, 'svetlana', 'qing', 'p1-resign');
-        console.log(`[Test 15] Game 1 (${game1Id}) → P1 resigned, score: 0-1`);
+        console.log(`[Game 3 DC] Game 1 (${game1Id}) → P1 resigned, score: 0-1`);
         await takeScreenshot('game1-resigned', player1);
       });
 
@@ -410,7 +406,7 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
       let game2Id = '';
       await test.step('Game 2: P1 resigns (0-2)', async () => {
         game2Id = await playOneGame(player1, player2, 'svetlana', 'qing', 'p1-resign');
-        console.log(`[Test 15] Game 2 (${game2Id}) → P1 resigned, score: 0-2`);
+        console.log(`[Game 3 DC] Game 2 (${game2Id}) → P1 resigned, score: 0-2`);
         await takeScreenshot('game2-resigned', player1);
       });
 
@@ -432,24 +428,24 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
 
       // Step 8: P2 disconnects during game 3
       await test.step('P2 (qing) disconnects during game 3', async () => {
-        console.log('[Test 15] Closing P2 page to simulate disconnect during game 3...');
+        console.log('[Game 3 DC] Closing P2 page to simulate disconnect during game 3...');
         await player2.close();
         await takeScreenshot('p1-after-p2-disconnect', player1);
 
         // Ensure it's P2's turn so "Claim victory" button can appear
         const myTurn = await isMyTurn(player1, 'svetlana');
         if (myTurn) {
-          console.log('[Test 15] P1 makes extra move to pass turn to disconnected P2...');
+          console.log('[Game 3 DC] P1 makes extra move to pass turn to disconnected P2...');
           await makeAnyMove(player1, 'svetlana');
           await takeScreenshot('p1-extra-move', player1);
         } else {
-          console.log('[Test 15] Already P2 turn, no extra move needed');
+          console.log('[Game 3 DC] Already P2 turn, no extra move needed');
         }
       });
 
       // Step 9: Wait for "Claim victory" button
       await test.step('P1 claims victory after disconnect timeout', async () => {
-        console.log('[Test 15] Waiting for "Claim victory" button (~60s)...');
+        console.log('[Game 3 DC] Waiting for "Claim victory" button (~60s)...');
 
         const forceResignBtn = player1.locator('div.suggestion button.button').first();
         await expect(forceResignBtn).toBeVisible({ timeout: 120000 });
@@ -457,7 +453,7 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
         await takeScreenshot('force-resign-visible', player1);
 
         await forceResignBtn.click();
-        console.log('[Test 15] Clicked "Claim victory"');
+        console.log('[Game 3 DC] Clicked "Claim victory"');
 
         await player1.waitForTimeout(2000);
         await takeScreenshot('after-force-resign', player1);
@@ -469,7 +465,7 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
         await player1.waitForTimeout(3000);
 
         const data = await getSeriesData(player1, seriesId);
-        console.log(`[Test 15] Series data: ${JSON.stringify(data)}`);
+        console.log(`[Game 3 DC] Series data: ${JSON.stringify(data)}`);
 
         expect(data).not.toBeNull();
         // status=20 (Started), NOT 30 (Finished) or 40 (Aborted)
@@ -486,7 +482,7 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
         expect(totalScore).toBe(3); // 3 decisive game results
 
         await takeScreenshot('series-continues', player1);
-        console.log(`[Test 15] Series continues with scores: ${data!.scores[0]}-${data!.scores[1]}`);
+        console.log(`[Game 3 DC] Series continues with scores: ${data!.scores[0]}-${data!.scores[1]}`);
       });
     } finally {
       await player1Context.close();
@@ -495,15 +491,14 @@ test.describe('Test 15: svetlana vs qing (0-2 then game 3 disconnect → game lo
   });
 });
 
-// ===== Test 21: Selecting Timeout → Random Pick (bug fix #4 + change #2) =====
-test.describe('Test 21: kwame vs sonia (Selecting timeout → random pick)', () => {
+test.describe('kwame vs sonia: Selecting timeout → random pick', () => {
   // Ban/pick + game 1 + resting + selecting timeout (30s) + game 2 start + buffer
   test.describe.configure({ timeout: 180000 });
 
   const pairUsers = ['kwame', 'sonia'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 21] Selecting timeout → random pick, game 2 starts', async ({ browser }) => {
+  test('Selecting timeout → random pick, game 2 starts', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.kwame,
@@ -538,7 +533,7 @@ test.describe('Test 21: kwame vs sonia (Selecting timeout → random pick)', () 
       // Step 3: Game 1 - P2 resigns → P1 wins (1-0)
       await test.step('Game 1: P2 resigns (P1 wins)', async () => {
         const gameId = await playOneGame(player1, player2, 'kwame', 'sonia', 'p2-resign');
-        console.log(`[Test 21] Game 1 (${gameId}) → P2 resigned, score: 1-0`);
+        console.log(`[Selecting Timeout] Game 1 (${gameId}) → P2 resigned, score: 1-0`);
         await takeScreenshot('game1-p2-resigned', player1);
       });
 
@@ -561,7 +556,7 @@ test.describe('Test 21: kwame vs sonia (Selecting timeout → random pick)', () 
       await test.step('Selecting timeout (30s) → random pick', async () => {
         // Wait for Selecting phase to start (P2 is loser, should see selecting UI)
         // The server schedules a 30s timeout for Selecting phase (bug fix #4)
-        console.log('[Test 21] Waiting for Selecting timeout (30s)...');
+        console.log('[Selecting Timeout] Waiting for Selecting timeout (30s)...');
 
         // Poll the API until game 2 is created (gamesCount >= 2)
         // Selecting timeout = 30s, plus processing time
@@ -570,7 +565,7 @@ test.describe('Test 21: kwame vs sonia (Selecting timeout → random pick)', () 
         for (let i = 1; i <= 20; i++) {
           await player1.waitForTimeout(2000);
           data = await getSeriesData(player1, seriesId);
-          console.log(`[Test 21] attempt=${i}, phase=${data?.phase}, games=${data?.gamesCount}`);
+          console.log(`[Selecting Timeout] attempt=${i}, phase=${data?.phase}, games=${data?.gamesCount}`);
           if (data && data.gamesCount >= 2) break;
         }
 
@@ -578,13 +573,13 @@ test.describe('Test 21: kwame vs sonia (Selecting timeout → random pick)', () 
 
         expect(data).not.toBeNull();
         expect(data!.gamesCount).toBe(2);
-        console.log(`[Test 21] Game 2 started after Selecting timeout (random pick)`);
+        console.log(`[Selecting Timeout] Game 2 started after Selecting timeout (random pick)`);
       });
 
       // Step 6: Verify series continues normally
       await test.step('Verify series state after random pick', async () => {
         const data = await getSeriesData(player1, seriesId);
-        console.log(`[Test 21] Series data: ${JSON.stringify(data)}`);
+        console.log(`[Selecting Timeout] Series data: ${JSON.stringify(data)}`);
 
         expect(data).not.toBeNull();
         expect(data!.status).toBe(20);        // Started
@@ -601,15 +596,14 @@ test.describe('Test 21: kwame vs sonia (Selecting timeout → random pick)', () 
   });
 });
 
-// ===== Test 22: Resting Both DC → Series Abort (change #3) =====
-test.describe('Test 22: tomoko vs renata (Resting both DC → abort)', () => {
+test.describe('tomoko vs renata: Resting both DC → abort', () => {
   // Ban/pick + game 1 + resting timeout (30s) + DC detection + buffer
   test.describe.configure({ timeout: 150000 });
 
   const pairUsers = ['tomoko', 'renata'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 22] Resting both DC → series abort', async ({ browser }) => {
+  test('Resting both DC → series abort', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.tomoko,
@@ -644,7 +638,7 @@ test.describe('Test 22: tomoko vs renata (Resting both DC → abort)', () => {
       // Step 3: Game 1 - P1 resigns → P2 wins
       await test.step('Game 1: P1 resigns', async () => {
         const gameId = await playOneGame(player1, player2, 'tomoko', 'renata', 'p1-resign');
-        console.log(`[Test 22] Game 1 (${gameId}) → P1 resigned`);
+        console.log(`[Resting Both DC] Game 1 (${gameId}) → P1 resigned`);
         await takeScreenshot('game1-resigned', player1);
       });
 
@@ -673,7 +667,7 @@ test.describe('Test 22: tomoko vs renata (Resting both DC → abort)', () => {
 
       // Step 6: Both players disconnect
       await test.step('Both players disconnect during Resting', async () => {
-        console.log('[Test 22] Closing both pages to simulate both-DC...');
+        console.log('[Resting Both DC] Closing both pages to simulate both-DC...');
         await player2.close();
         await player1.close();
       });
@@ -685,7 +679,7 @@ test.describe('Test 22: tomoko vs renata (Resting both DC → abort)', () => {
 
         // Resting timeout = 30s, DC threshold = 5s, server processing = ~2s
         // 20 retries × 2s = 40s total (covers 30s timeout + margin)
-        console.log('[Test 22] Waiting for Resting timeout and both-DC abort...');
+        console.log('[Resting Both DC] Waiting for Resting timeout and both-DC abort...');
         const aborted = await isSeriesAborted(verifyPage, seriesId, 20);
 
         await test.info().attach('after-abort', {
@@ -694,7 +688,7 @@ test.describe('Test 22: tomoko vs renata (Resting both DC → abort)', () => {
         });
 
         expect(aborted).toBe(true);
-        console.log(`[Test 22] Series ${seriesId} aborted (both DC during Resting)`);
+        console.log(`[Resting Both DC] Series ${seriesId} aborted (both DC during Resting)`);
 
         await verifyPage.close();
       });
@@ -705,15 +699,14 @@ test.describe('Test 22: tomoko vs renata (Resting both DC → abort)', () => {
   });
 });
 
-// ===== Test 23: Resting 1 DC → Series Forfeit =====
-test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
+test.describe('yarah vs suresh: Resting 1 DC → forfeit', () => {
   // Ban/pick + game 1 + resting timeout (30s) + DC detection + finished page + buffer
   test.describe.configure({ timeout: 150000 });
 
   const pairUsers = ['yarah', 'suresh'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 23] Resting 1 DC → series forfeit (P1 wins)', async ({ browser }) => {
+  test('Resting 1 DC → series forfeit (P1 wins)', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.yarah,
@@ -748,7 +741,7 @@ test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
       // Step 3: Game 1 - P1 resigns → P2 wins
       await test.step('Game 1: P1 resigns', async () => {
         const gameId = await playOneGame(player1, player2, 'yarah', 'suresh', 'p1-resign');
-        console.log(`[Test 23] Game 1 (${gameId}) → P1 resigned`);
+        console.log(`[Resting 1 DC] Game 1 (${gameId}) → P1 resigned`);
         await takeScreenshot('game1-resigned', player1);
       });
 
@@ -776,7 +769,7 @@ test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
 
       // Step 6: P2 disconnects
       await test.step('P2 (suresh) disconnects during Resting', async () => {
-        console.log('[Test 23] Closing P2 page to simulate disconnect...');
+        console.log('[Resting 1 DC] Closing P2 page to simulate disconnect...');
         await player2.close();
         await takeScreenshot('p1-after-p2-disconnect', player1);
       });
@@ -784,7 +777,7 @@ test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
       // Step 7: Verify DC warning UI on P1
       await test.step('Verify "Opponent left" warning on P1', async () => {
         // Wait for P1's poll to detect P2's DC (~3s poll + 5s threshold = ~8s)
-        console.log('[Test 23] Waiting for DC detection on P1 poll...');
+        console.log('[Resting 1 DC] Waiting for DC detection on P1 poll...');
 
         // The poll fires every 3s and checks isOnline (5s threshold).
         // After P2 disconnects, worst case: next poll in 3s + 5s stale = 8s
@@ -798,19 +791,19 @@ test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
         ).toBeVisible({ timeout: 3000 });
 
         await takeScreenshot('p1-opponent-left-warning', player1);
-        console.log('[Test 23] DC warning UI confirmed on P1');
+        console.log('[Resting 1 DC] DC warning UI confirmed on P1');
       });
 
       // Step 7: Wait for Resting timeout → forfeit → redirect to Finished
       await test.step('Wait for forfeit and redirect to Finished page', async () => {
-        console.log('[Test 23] Waiting for Resting timeout → forfeit → redirect...');
+        console.log('[Resting 1 DC] Waiting for Resting timeout → forfeit → redirect...');
 
         // Resting timeout = 30s from phase start.
         // We already waited ~8-12s for DC detection, so ~18-22s remaining.
         await waitForFinishedPage(player1, seriesId, 40000);
 
         await takeScreenshot('finished-page-p1', player1);
-        console.log('[Test 23] P1 redirected to Finished page');
+        console.log('[Resting 1 DC] P1 redirected to Finished page');
       });
 
       // Step 8: Verify Finished page shows "Victory! (forfeit)"
@@ -821,13 +814,13 @@ test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
         expect(banner).toContain('forfeit');
 
         await takeScreenshot('finished-ui-verified', player1);
-        console.log(`[Test 23] Finished page banner: "${banner}"`);
+        console.log(`[Resting 1 DC] Finished page banner: "${banner}"`);
       });
 
       // Step 9: Verify series data via API
       await test.step('Verify series API data (forfeit)', async () => {
         const data = await getSeriesData(player1, seriesId);
-        console.log(`[Test 23] Series data: ${JSON.stringify(data)}`);
+        console.log(`[Resting 1 DC] Series data: ${JSON.stringify(data)}`);
 
         expect(data).not.toBeNull();
         expect(data!.status).toBe(30);           // Finished
@@ -836,7 +829,7 @@ test.describe('Test 23: yarah vs suresh (Resting 1 DC → forfeit)', () => {
         expect(data!.gamesCount).toBe(1);         // 1 game played
 
         await takeScreenshot('api-data-verified', player1);
-        console.log(`[Test 23] Series ${seriesId} forfeited successfully`);
+        console.log(`[Resting 1 DC] Series ${seriesId} forfeited successfully`);
       });
     } finally {
       await player1Context.close();

--- a/tests/e2e/specs/series-finished-mobile.spec.ts
+++ b/tests/e2e/specs/series-finished-mobile.spec.ts
@@ -27,7 +27,7 @@ import {
 
 const MOBILE_VIEWPORT = { width: 320, height: 568 };
 
-test.describe('gabriela vs guang: Finished page mobile scroll', () => {
+test.describe('gabriela vs guang: Finished page mobile scroll @phase:pick @phase:ban @phase:game @feature:mobile @scope:slow', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['gabriela', 'guang'];

--- a/tests/e2e/specs/series-finished-mobile.spec.ts
+++ b/tests/e2e/specs/series-finished-mobile.spec.ts
@@ -20,21 +20,20 @@ import {
  * Strategy: Play the series on desktop viewport (board clicks need space),
  * then switch to mobile viewport on the finished page to verify scrollability.
  *
- * | # | P1 | P2 | Scenario |
- * |---|----|----|----------|
- * | 29 | gabriela | guang | 3-0 sweep → mobile finished page table scroll |
+ * | P1 | P2 | Scenario |
+ * |----|----|----------|
+ * | gabriela | guang | 3-0 sweep → mobile finished page table scroll |
  */
 
 const MOBILE_VIEWPORT = { width: 320, height: 568 };
 
-// ===== Test 29: Finished Page Mobile Scroll =====
-test.describe('Test 29: gabriela vs guang (Finished page mobile scroll)', () => {
+test.describe('gabriela vs guang: Finished page mobile scroll', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['gabriela', 'guang'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 29] Score table is scrollable on mobile viewport', async ({ browser }) => {
+  test('Score table is scrollable on mobile viewport', async ({ browser }) => {
     // Play series on desktop viewport (board clicks require adequate size)
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
@@ -59,7 +58,7 @@ test.describe('Test 29: gabriela vs guang (Finished page mobile scroll)', () => 
       await test.step('Create series', async () => {
         await loginBothPlayers(player1, player2, users.gabriela, users.guang);
         seriesId = await createSeriesChallenge(player1, player2, 'guang');
-        console.log(`[Test 29] Series created: ${seriesId}`);
+        console.log(`[Finished Mobile] Series created: ${seriesId}`);
       });
 
       // ===== STEP 2: Complete Ban/Pick Phase =====
@@ -102,7 +101,7 @@ test.describe('Test 29: gabriela vs guang (Finished page mobile scroll)', () => 
           overflowX: getComputedStyle(el).overflowX,
         }));
 
-        console.log(`[Test 29] Score table scroll info:`, scrollInfo);
+        console.log(`[Finished Mobile] Score table scroll info:`, scrollInfo);
 
         // overflow-x should be 'auto' (CSS fix enables scrolling when content overflows)
         expect(scrollInfo.overflowX).toBe('auto');

--- a/tests/e2e/specs/series-finished.spec.ts
+++ b/tests/e2e/specs/series-finished.spec.ts
@@ -31,7 +31,7 @@ import {
  * | patricia | adriana | 3-0 sweep → finished page + rematch flow |
  */
 
-test.describe('patricia vs adriana: Finished page + Rematch', () => {
+test.describe('patricia vs adriana: Finished page + Rematch @phase:pick @phase:ban @phase:game @phase:resting @feature:rematch @scope:slow', () => {
   // 3-game sweep (fast) + rematch flow
   test.describe.configure({ timeout: 120000 });
 

--- a/tests/e2e/specs/series-finished.spec.ts
+++ b/tests/e2e/specs/series-finished.spec.ts
@@ -26,20 +26,19 @@ import {
  * - Rematch offer → opponent sees glowing button → accept → new series
  * - Home button navigation
  *
- * | # | P1 | P2 | Scenario |
- * |---|----|----|----------|
- * | 11 | patricia | adriana | 3-0 sweep → finished page + rematch flow |
+ * | P1 | P2 | Scenario |
+ * |----|----|----------|
+ * | patricia | adriana | 3-0 sweep → finished page + rematch flow |
  */
 
-// ===== Test 11: Finished Page + Rematch =====
-test.describe('Test 11: patricia vs adriana (Finished page + Rematch)', () => {
+test.describe('patricia vs adriana: Finished page + Rematch', () => {
   // 3-game sweep (fast) + rematch flow
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['patricia', 'adriana'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 11] Finished page UI + rematch offer/accept', async ({ browser }) => {
+  test('Finished page UI + rematch offer/accept', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.patricia,
@@ -64,9 +63,9 @@ test.describe('Test 11: patricia vs adriana (Finished page + Rematch)', () => {
         await loginBothPlayers(player1, player2, users.patricia, users.adriana);
         seriesId = await createSeriesChallenge(player1, player2, 'adriana');
         await takeScreenshot('series-created', player1);
-        console.log(`[Test 11] Series created: ${seriesId}`);
-        console.log(`[Test 11] P1 URL: ${player1.url()}`);
-        console.log(`[Test 11] P2 URL: ${player2.url()}`);
+        console.log(`[Finished] Series created: ${seriesId}`);
+        console.log(`[Finished] P1 URL: ${player1.url()}`);
+        console.log(`[Finished] P2 URL: ${player2.url()}`);
       });
 
       // ===== STEP 2: Complete Ban/Pick Phase =====
@@ -188,7 +187,7 @@ test.describe('Test 11: patricia vs adriana (Finished page + Rematch)', () => {
         await takeScreenshot('rematch-new-series-p1', player1);
         await takeScreenshot('rematch-new-series-p2', player2);
 
-        console.log(`[Test 11] Rematch: old series=${seriesId}, new series=${newSeriesIdP1}`);
+        console.log(`[Finished] Rematch: old series=${seriesId}, new series=${newSeriesIdP1}`);
       });
     } finally {
       await player1Context.close();

--- a/tests/e2e/specs/series-forfeit.spec.ts
+++ b/tests/e2e/specs/series-forfeit.spec.ts
@@ -31,7 +31,7 @@ import { verifyOpeningsTab } from '../helpers/openings-tab';
  * | salma | benjamin | Forfeit before moves | Game abort, series finished, P2 wins |
  */
 
-test.describe('fatima vs diego: Forfeit after moves', () => {
+test.describe('fatima vs diego: Forfeit after moves @phase:pick @phase:ban @phase:game @feature:forfeit @scope:quick', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['fatima', 'diego'];
@@ -167,7 +167,7 @@ test.describe('fatima vs diego: Forfeit after moves', () => {
   });
 });
 
-test.describe('salma vs benjamin: Forfeit before moves', () => {
+test.describe('salma vs benjamin: Forfeit before moves @phase:pick @phase:ban @phase:game @feature:forfeit @scope:quick', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['salma', 'benjamin'];

--- a/tests/e2e/specs/series-forfeit.spec.ts
+++ b/tests/e2e/specs/series-forfeit.spec.ts
@@ -25,20 +25,19 @@ import { verifyOpeningsTab } from '../helpers/openings-tab';
  * - Clicking X shows confirm dialog, confirming forfeits the entire series
  * - Forfeit ends current game (resign if moves played, abort if not) and series
  *
- * | # | P1 | P2 | Scenario | Expected |
- * |---|----|----|----------|----------|
- * | 9 | fatima | diego | Forfeit after moves | Game resign, series finished, P2 wins |
- * | 10 | salma | benjamin | Forfeit before moves | Game abort, series finished, P2 wins |
+ * | P1 | P2 | Scenario | Expected |
+ * |----|----|----------|----------|
+ * | fatima | diego | Forfeit after moves | Game resign, series finished, P2 wins |
+ * | salma | benjamin | Forfeit before moves | Game abort, series finished, P2 wins |
  */
 
-// ===== Test 9: Forfeit during active game (after moves) =====
-test.describe('Test 9: fatima vs diego (Forfeit after moves)', () => {
+test.describe('fatima vs diego: Forfeit after moves', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['fatima', 'diego'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 9] Forfeit after moves → game resign, series finished', async ({ browser }) => {
+  test('Forfeit after moves → game resign, series finished', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.fatima,
@@ -91,7 +90,7 @@ test.describe('Test 9: fatima vs diego (Forfeit after moves)', () => {
 
         const buttons = ricons.locator('button.fbt');
         const buttonCount = await buttons.count();
-        console.log(`[Test 9] Button count in .ricons: ${buttonCount}`);
+        console.log(`[Forfeit Moves] Button count in .ricons: ${buttonCount}`);
         // 4 action buttons + analysis + board menu = 6 (but analysis may not be visible during play)
         expect(buttonCount).toBeGreaterThanOrEqual(4);
 
@@ -136,7 +135,7 @@ test.describe('Test 9: fatima vs diego (Forfeit after moves)', () => {
         // Player ordering depends on random color, not who created the challenge
         const fatimaIndex = await getPlayerIndex(player1, seriesId, 'fatima');
         const winner = await getSeriesWinner(player1, seriesId);
-        console.log(`[Test 9] fatima index: ${fatimaIndex}, winner index: ${winner}`);
+        console.log(`[Forfeit Moves] fatima index: ${fatimaIndex}, winner index: ${winner}`);
         // fatima forfeits → the opponent (diego) should win
         expect(winner).not.toBeNull();
         expect(fatimaIndex).not.toBeNull();
@@ -168,14 +167,13 @@ test.describe('Test 9: fatima vs diego (Forfeit after moves)', () => {
   });
 });
 
-// ===== Test 10: Forfeit at game start (no moves) =====
-test.describe('Test 10: salma vs benjamin (Forfeit before moves)', () => {
+test.describe('salma vs benjamin: Forfeit before moves', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['salma', 'benjamin'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 10] Forfeit before moves → game abort, series finished', async ({ browser }) => {
+  test('Forfeit before moves → game abort, series finished', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.salma,
@@ -243,7 +241,7 @@ test.describe('Test 10: salma vs benjamin (Forfeit before moves)', () => {
         // Player ordering depends on random color, not who created the challenge
         const salmaIndex = await getPlayerIndex(player1, seriesId, 'salma');
         const winner = await getSeriesWinner(player1, seriesId);
-        console.log(`[Test 10] salma index: ${salmaIndex}, winner index: ${winner}`);
+        console.log(`[Forfeit No Moves] salma index: ${salmaIndex}, winner index: ${winner}`);
         // salma forfeits → the opponent (benjamin) should win
         expect(winner).not.toBeNull();
         expect(salmaIndex).not.toBeNull();

--- a/tests/e2e/specs/series-lobby.spec.ts
+++ b/tests/e2e/specs/series-lobby.spec.ts
@@ -23,7 +23,7 @@ import {
  * | elizabeth | dae | Lobby hook matching → series → ban/pick → game |
  */
 
-test.describe('elizabeth vs dae: Lobby matching', () => {
+test.describe('elizabeth vs dae: Lobby matching @phase:pick @phase:ban @phase:game @feature:lobby @scope:quick', () => {
   test.describe.configure({ timeout: 180000 });
 
   const pairUsers = ['elizabeth', 'dae'];

--- a/tests/e2e/specs/series-lobby.spec.ts
+++ b/tests/e2e/specs/series-lobby.spec.ts
@@ -18,18 +18,18 @@ import {
  * - Both redirected to /series/{id}/pick (no challenge accept step)
  * - Completes ban/pick, plays one game, verifies series is active
  *
- * | Test | P1 | P2 | Scenario |
- * |------|----|----|----------|
- * | 27   | elizabeth | dae | Lobby hook matching → series → ban/pick → game |
+ * | P1 | P2 | Scenario |
+ * |----|----|----------|
+ * | elizabeth | dae | Lobby hook matching → series → ban/pick → game |
  */
 
-test.describe('Test 27: elizabeth vs dae (Lobby matching)', () => {
+test.describe('elizabeth vs dae: Lobby matching', () => {
   test.describe.configure({ timeout: 180000 });
 
   const pairUsers = ['elizabeth', 'dae'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 27] Opening Duel with Anyone → series creation → game', async ({ browser }) => {
+  test('Opening Duel with Anyone → series creation → game', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } =
       await createTwoPlayerContexts(browser, users.elizabeth, users.dae);
 

--- a/tests/e2e/specs/series-nostart.spec.ts
+++ b/tests/e2e/specs/series-nostart.spec.ts
@@ -40,6 +40,7 @@ import {
  * |----|----|----|----------|
  * | yunel | idris | Neither player moves | First mover (startColor) loses, opponent +1pt |
  * | aleksandr | veer | First mover moves, second doesn't | Second mover loses, first mover +1pt |
+ * | monica | yun | 15s wait after animation, then Game 2 NoStart | NoStart timer delayed until animation done |
  */
 
 test.describe('yunel vs idris: NoStart - neither moves @phase:pick @phase:ban @phase:game @feature:nostart @scope:slow', () => {
@@ -288,18 +289,18 @@ test.describe('aleksandr vs veer: NoStart - second mover doesn\'t move @phase:pi
   });
 });
 
-test.describe('aleksandr vs veer: NoStart timer delayed until animation done @phase:pick @phase:ban @phase:game @feature:nostart @scope:slow', () => {
+test.describe('monica vs yun: NoStart timer delayed until animation done @phase:pick @phase:ban @phase:game @feature:nostart @scope:slow', () => {
   // 15s wait + Resting 30s + Selecting 30s + NoStart 26s + buffer
   test.describe.configure({ timeout: 240000 });
 
-  const pairUsers = ['aleksandr', 'veer'];
+  const pairUsers = ['monica', 'yun'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
   test('15s wait after animation → no NoStart, then Game 2 NoStart fires', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
-      users.aleksandr,
-      users.veer
+      users.monica,
+      users.yun
     );
 
     let screenshotCounter = 0;
@@ -317,8 +318,8 @@ test.describe('aleksandr vs veer: NoStart timer delayed until animation done @ph
     try {
       // Step 1: Create series
       await test.step('Create series', async () => {
-        await loginBothPlayers(player1, player2, users.aleksandr, users.veer);
-        seriesId = await createSeriesChallenge(player1, player2, 'veer');
+        await loginBothPlayers(player1, player2, users.monica, users.yun);
+        seriesId = await createSeriesChallenge(player1, player2, 'yun');
       });
 
       // Step 2: Complete ban/pick phase
@@ -342,7 +343,7 @@ test.describe('aleksandr vs veer: NoStart timer delayed until animation done @ph
         await takeScreenshot('game1-after-15s-wait', player1);
 
         // Both make their first move — proves neither was NoStart'd
-        await playBothMoves(player1, player2, 'aleksandr', 'veer');
+        await playBothMoves(player1, player2, 'monica', 'yun');
         console.log('[NoStart Timer] Both players moved after 15s wait — NoStart did NOT fire');
         await takeScreenshot('game1-both-moved', player1);
       });
@@ -352,7 +353,7 @@ test.describe('aleksandr vs veer: NoStart timer delayed until animation done @ph
       await test.step('Resign game 1 → transition to game 2', async () => {
         game1Id = getGameIdFromUrl(player1.url()) || '';
         await resignGame(player1);
-        console.log(`[NoStart Timer] Game 1 (${game1Id}) resigned by aleksandr`);
+        console.log(`[NoStart Timer] Game 1 (${game1Id}) resigned by monica`);
 
         // waitForNextGame handles: Resting → confirm → Selecting timeout → new game arrival
         await waitForNextGame(player1, player2, null, game1Id, 90000, takeScreenshot, 2);

--- a/tests/e2e/specs/series-nostart.spec.ts
+++ b/tests/e2e/specs/series-nostart.spec.ts
@@ -36,20 +36,19 @@ import {
  * - isMandatory = true → NoStart gives opponent the win (Status.NoStart)
  * - isDisconnectForfeit = false → series continues (not series-wide forfeit)
  *
- * | # | P1 | P2 | Scenario | Expected |
- * |---|----|----|----------|----------|
- * | 21 | yunel | idris | Neither player moves | First mover (startColor) loses, opponent +1pt |
- * | 22 | aleksandr | veer | First mover moves, second doesn't | Second mover loses, first mover +1pt |
+ * | P1 | P2 | Scenario | Expected |
+ * |----|----|----|----------|
+ * | yunel | idris | Neither player moves | First mover (startColor) loses, opponent +1pt |
+ * | aleksandr | veer | First mover moves, second doesn't | Second mover loses, first mover +1pt |
  */
 
-// ===== Test 21: NoStart - neither player moves =====
-test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
+test.describe('yunel vs idris: NoStart - neither moves', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['yunel', 'idris'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 21] Neither player moves → first mover loses via NoStart', async ({ browser }) => {
+  test('Neither player moves → first mover loses via NoStart', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.yunel,
@@ -92,13 +91,13 @@ test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
         const gameId = getGameIdFromUrl(player1.url());
         if (gameId) {
           const gameState = await getGameState(player1, gameId);
-          console.log(`[Test 21] White: ${gameState.whitePlayer}, Black: ${gameState.blackPlayer}`);
+          console.log(`[NoStart Neither] White: ${gameState.whitePlayer}, Black: ${gameState.blackPlayer}`);
         }
       });
 
       // Step 4: Wait for NoStart to fire (~26s) → Resting UI appears
       await test.step('Wait for NoStart timeout → Resting phase', async () => {
-        console.log('[Test 21] Waiting for NoStart timeout (~26 seconds)...');
+        console.log('[NoStart Neither] Waiting for NoStart timeout (~26 seconds)...');
 
         // NoStart fires at ~26s from game creation, series transitions to Resting
         await Promise.all([
@@ -108,7 +107,7 @@ test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
 
         await takeScreenshot('resting-after-nostart-p1', player1);
         await takeScreenshot('resting-after-nostart-p2', player2);
-        console.log('[Test 21] Resting UI appeared - NoStart fired successfully');
+        console.log('[NoStart Neither] Resting UI appeared - NoStart fired successfully');
       });
 
       // Step 5: Verify series score via API
@@ -120,7 +119,7 @@ test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
             headers: { Accept: 'application/json' },
           });
           const body = await response.text();
-          console.log(`[Test 21] API attempt ${attempt}: status=${response.status()}, body=${body.slice(0, 200)}`);
+          console.log(`[NoStart Neither] API attempt ${attempt}: status=${response.status()}, body=${body.slice(0, 200)}`);
 
           if (response.ok()) {
             data = JSON.parse(body);
@@ -134,7 +133,7 @@ test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
         const p0Score = players[0].score;
         const p1Score = players[1].score;
 
-        console.log(`[Test 21] Scores: P0=${p0Score}, P1=${p1Score}`);
+        console.log(`[NoStart Neither] Scores: P0=${p0Score}, P1=${p1Score}`);
 
         // API returns displayScore: win=1, draw=0.5, loss=0
         // Exactly one player should have 1 point, the other 0
@@ -150,7 +149,7 @@ test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
         // Verify series is now finished
         const finished = await isSeriesFinished(player1, seriesId, 5);
         expect(finished).toBe(true);
-        console.log('[Test 21] Series forfeited and finished');
+        console.log('[NoStart Neither] Series forfeited and finished');
       });
     } finally {
       await player1Context.close();
@@ -159,14 +158,13 @@ test.describe('Test 21: yunel vs idris (NoStart - neither moves)', () => {
   });
 });
 
-// ===== Test 22: NoStart - first mover moves, second mover doesn't =====
-test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)', () => {
+test.describe('aleksandr vs veer: NoStart - second mover doesn\'t move', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['aleksandr', 'veer'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 22] First mover moves, second doesn\'t → second mover loses via NoStart', async ({ browser }) => {
+  test('First mover moves, second doesn\'t → second mover loses via NoStart', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.aleksandr,
@@ -209,11 +207,11 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
 
         if (p1IsFirstMover) {
           firstMoverUsername = 'aleksandr';
-          console.log('[Test 22] aleksandr is first mover (startColor) - making move');
+          console.log('[NoStart Second] aleksandr is first mover (startColor) - making move');
           await makeAnyMove(player1, 'aleksandr');
         } else {
           firstMoverUsername = 'veer';
-          console.log('[Test 22] veer is first mover (startColor) - making move');
+          console.log('[NoStart Second] veer is first mover (startColor) - making move');
           await makeAnyMove(player2, 'veer');
         }
 
@@ -221,12 +219,12 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
         await takeScreenshot('after-first-move-p2', player2);
 
         // Second mover does NOT move - wait for NoStart
-        console.log(`[Test 22] Second mover will NOT move. Waiting for NoStart...`);
+        console.log(`[NoStart Second] Second mover will NOT move. Waiting for NoStart...`);
       });
 
       // Step 4: Wait for NoStart to fire (~26s) → Resting UI appears
       await test.step('Wait for NoStart timeout → Resting phase', async () => {
-        console.log('[Test 22] Waiting for NoStart timeout (~26 seconds)...');
+        console.log('[NoStart Second] Waiting for NoStart timeout (~26 seconds)...');
 
         await Promise.all([
           waitForRestingUI(player1, 45000),
@@ -235,7 +233,7 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
 
         await takeScreenshot('resting-after-nostart-p1', player1);
         await takeScreenshot('resting-after-nostart-p2', player2);
-        console.log('[Test 22] Resting UI appeared - NoStart fired successfully');
+        console.log('[NoStart Second] Resting UI appeared - NoStart fired successfully');
       });
 
       // Step 5: Verify series score - first mover should have the point
@@ -247,7 +245,7 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
             headers: { Accept: 'application/json' },
           });
           const body = await response.text();
-          console.log(`[Test 22] API attempt ${attempt}: status=${response.status()}, body=${body.slice(0, 200)}`);
+          console.log(`[NoStart Second] API attempt ${attempt}: status=${response.status()}, body=${body.slice(0, 200)}`);
 
           if (response.ok()) {
             data = JSON.parse(body);
@@ -266,7 +264,7 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
         const firstMoverScore = players[firstMoverIdx].score;
         const secondMoverScore = players[secondMoverIdx].score;
 
-        console.log(`[Test 22] First mover (${firstMoverUsername}, idx=${firstMoverIdx}) score=${firstMoverScore}, Second mover score=${secondMoverScore}`);
+        console.log(`[NoStart Second] First mover (${firstMoverUsername}, idx=${firstMoverIdx}) score=${firstMoverScore}, Second mover score=${secondMoverScore}`);
 
         // API returns displayScore: win=1, draw=0.5, loss=0
         // First mover should have won (1 point), second mover should have 0
@@ -281,7 +279,7 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
 
         const finished = await isSeriesFinished(player1, seriesId, 5);
         expect(finished).toBe(true);
-        console.log('[Test 22] Series forfeited and finished');
+        console.log('[NoStart Second] Series forfeited and finished');
       });
     } finally {
       await player1Context.close();
@@ -290,15 +288,14 @@ test.describe('Test 22: aleksandr vs veer (NoStart - second mover doesn\'t move)
   });
 });
 
-// ===== Test 23: NoStart timer starts after RandomSelecting animation =====
-test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation done)', () => {
+test.describe('aleksandr vs veer: NoStart timer delayed until animation done', () => {
   // 15s wait + Resting 30s + Selecting 30s + NoStart 26s + buffer
   test.describe.configure({ timeout: 240000 });
 
   const pairUsers = ['aleksandr', 'veer'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 23] 15s wait after animation → no NoStart, then Game 2 NoStart fires', async ({ browser }) => {
+  test('15s wait after animation → no NoStart, then Game 2 NoStart fires', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.aleksandr,
@@ -338,7 +335,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
 
         // Wait 15 seconds — longer than old effective NoStart window (~12s)
         // but shorter than correct timeForFirstMove (25s for Blitz)
-        console.log('[Test 23] Waiting 15 seconds after board visible...');
+        console.log('[NoStart Timer] Waiting 15 seconds after board visible...');
         await player1.waitForTimeout(15000);
 
         // Both players should still be able to move (NoStart hasn't fired)
@@ -346,7 +343,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
 
         // Both make their first move — proves neither was NoStart'd
         await playBothMoves(player1, player2, 'aleksandr', 'veer');
-        console.log('[Test 23] Both players moved after 15s wait — NoStart did NOT fire');
+        console.log('[NoStart Timer] Both players moved after 15s wait — NoStart did NOT fire');
         await takeScreenshot('game1-both-moved', player1);
       });
 
@@ -355,7 +352,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
       await test.step('Resign game 1 → transition to game 2', async () => {
         game1Id = getGameIdFromUrl(player1.url()) || '';
         await resignGame(player1);
-        console.log(`[Test 23] Game 1 (${game1Id}) resigned by aleksandr`);
+        console.log(`[NoStart Timer] Game 1 (${game1Id}) resigned by aleksandr`);
 
         // waitForNextGame handles: Resting → confirm → Selecting timeout → new game arrival
         await waitForNextGame(player1, player2, null, game1Id, 90000, takeScreenshot, 2);
@@ -368,7 +365,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
         await expect(player2.locator(gameSelectors.board)).toBeVisible({ timeout: 15000 });
         await takeScreenshot('game2-board-visible', player1);
 
-        console.log('[Test 23] Waiting for NoStart in Game 2...');
+        console.log('[NoStart Timer] Waiting for NoStart in Game 2...');
 
         // Wait for Resting UI (NoStart fires → game ends → Resting)
         await Promise.all([
@@ -376,7 +373,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
           waitForRestingUI(player2, 60000),
         ]);
         await takeScreenshot('resting-after-game2-nostart', player1);
-        console.log('[Test 23] NoStart fired in Game 2');
+        console.log('[NoStart Timer] NoStart fired in Game 2');
       });
 
       // Step 6: Verify scores — Game 1: veer won (aleksandr resigned), Game 2: NoStart
@@ -399,7 +396,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
         const players = data.players as Array<{ user?: { id: string }; score: number }>;
         const p0Score = players[0].score;
         const p1Score = players[1].score;
-        console.log(`[Test 23] Scores after 2 games: P0=${p0Score}, P1=${p1Score}`);
+        console.log(`[NoStart Timer] Scores after 2 games: P0=${p0Score}, P1=${p1Score}`);
 
         // Both games should have results (total score = 2)
         expect(p0Score + p1Score).toBe(2);
@@ -410,7 +407,7 @@ test.describe('Test 23: aleksandr vs veer (NoStart timer delayed until animation
         await forfeitSeriesViaApi(player1, seriesId);
         const finished = await isSeriesFinished(player1, seriesId, 5);
         expect(finished).toBe(true);
-        console.log('[Test 23] Series forfeited and finished');
+        console.log('[NoStart Timer] Series forfeited and finished');
       });
     } finally {
       await player1Context.close();

--- a/tests/e2e/specs/series-nostart.spec.ts
+++ b/tests/e2e/specs/series-nostart.spec.ts
@@ -42,7 +42,7 @@ import {
  * | aleksandr | veer | First mover moves, second doesn't | Second mover loses, first mover +1pt |
  */
 
-test.describe('yunel vs idris: NoStart - neither moves', () => {
+test.describe('yunel vs idris: NoStart - neither moves @phase:pick @phase:ban @phase:game @feature:nostart @scope:slow', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['yunel', 'idris'];
@@ -158,7 +158,7 @@ test.describe('yunel vs idris: NoStart - neither moves', () => {
   });
 });
 
-test.describe('aleksandr vs veer: NoStart - second mover doesn\'t move', () => {
+test.describe('aleksandr vs veer: NoStart - second mover doesn\'t move @phase:pick @phase:ban @phase:game @feature:nostart @scope:slow', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['aleksandr', 'veer'];
@@ -288,7 +288,7 @@ test.describe('aleksandr vs veer: NoStart - second mover doesn\'t move', () => {
   });
 });
 
-test.describe('aleksandr vs veer: NoStart timer delayed until animation done', () => {
+test.describe('aleksandr vs veer: NoStart timer delayed until animation done @phase:pick @phase:ban @phase:game @feature:nostart @scope:slow', () => {
   // 15s wait + Resting 30s + Selecting 30s + NoStart 26s + buffer
   test.describe.configure({ timeout: 240000 });
 

--- a/tests/e2e/specs/series-pool-exhaustion.spec.ts
+++ b/tests/e2e/specs/series-pool-exhaustion.spec.ts
@@ -26,7 +26,7 @@ import {
  * | dmitry | milena | 6 draws → pool exhaustion → series Draw |
  */
 
-test.describe('dmitry vs milena: Pool exhaustion → series Draw', () => {
+test.describe('dmitry vs milena: Pool exhaustion → series Draw @phase:pick @phase:ban @phase:game @phase:resting @feature:pool @scope:slow', () => {
   // 6 games (draws) + ban/pick phase + resting phases + RandomSelecting (~13s each: roulette + showcase) + buffer
   test.describe.configure({ timeout: 300000 });
 

--- a/tests/e2e/specs/series-pool-exhaustion.spec.ts
+++ b/tests/e2e/specs/series-pool-exhaustion.spec.ts
@@ -21,20 +21,19 @@ import {
  * Total pool = 6 openings. After 6 consecutive draws, all openings are used
  * and the pool is empty. The series finishes with a tied score (3-3).
  *
- * | # | P1 | P2 | Scenario |
- * |---|----|----|----------|
- * | 17 | dmitry | milena | 6 draws → pool exhaustion → series Draw |
+ * | P1 | P2 | Scenario |
+ * |----|----|----------|
+ * | dmitry | milena | 6 draws → pool exhaustion → series Draw |
  */
 
-// ===== Test 17: Pool Exhaustion → Series Draw =====
-test.describe('Test 17: dmitry vs milena (Pool exhaustion → series Draw)', () => {
+test.describe('dmitry vs milena: Pool exhaustion → series Draw', () => {
   // 6 games (draws) + ban/pick phase + resting phases + RandomSelecting (~13s each: roulette + showcase) + buffer
   test.describe.configure({ timeout: 300000 });
 
   const pairUsers = ['dmitry', 'milena'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 17] 6 consecutive draws → pool exhaustion → Draw banner', async ({ browser }) => {
+  test('6 consecutive draws → pool exhaustion → Draw banner', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.dmitry,
@@ -59,7 +58,7 @@ test.describe('Test 17: dmitry vs milena (Pool exhaustion → series Draw)', () 
         await loginBothPlayers(player1, player2, users.dmitry, users.milena);
         seriesId = await createSeriesChallenge(player1, player2, 'milena');
         await takeScreenshot('series-created', player1);
-        console.log(`[Test 17] Series created: ${seriesId}`);
+        console.log(`[Pool Exhaustion] Series created: ${seriesId}`);
       });
 
       // ===== STEP 2: Complete Ban/Pick Phase =====
@@ -112,7 +111,7 @@ test.describe('Test 17: dmitry vs milena (Pool exhaustion → series Draw)', () 
         await takeScreenshot('finished-draw-p1', player1);
         await takeScreenshot('finished-draw-p2', player2);
 
-        console.log(`[Test 17] Both players see Draw banner. Series ${seriesId} ended as draw.`);
+        console.log(`[Pool Exhaustion] Both players see Draw banner. Series ${seriesId} ended as draw.`);
       });
     } finally {
       await player1Context.close();

--- a/tests/e2e/specs/series-reconnect-banner.spec.ts
+++ b/tests/e2e/specs/series-reconnect-banner.spec.ts
@@ -17,19 +17,19 @@ import {
  * returning to the home page shows a "Series in Progress" banner with a
  * "Return to Series" button that redirects back to the correct series page.
  *
- * | # | P1 | P2 | Phase | Action | Expected |
- * |---|----|----|-------|--------|----------|
- * | 26a | frances | emmanuel | Pick | P2 navigates to home | Banner visible, click returns to pick page |
- * | 26b | frances | emmanuel | Ban | P2 navigates to home | Banner visible, click returns to pick page |
+ * | P1 | P2 | Phase | Action | Expected |
+ * |----|----|-------|--------|----------|
+ * | frances | emmanuel | Pick | P2 navigates to home | Banner visible, click returns to pick page |
+ * | frances | emmanuel | Ban | P2 navigates to home | Banner visible, click returns to pick page |
  */
 
-test.describe('Test 26: frances vs emmanuel (Reconnection banner)', () => {
+test.describe('frances vs emmanuel: Reconnection banner', () => {
   test.describe.configure({ timeout: 90000 });
 
   const pairUsers = ['frances', 'emmanuel'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 26] Reconnection banner shows on home page during Pick/Ban phases', async ({ browser }) => {
+  test('Reconnection banner shows on home page during Pick/Ban phases', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.frances,

--- a/tests/e2e/specs/series-reconnect-banner.spec.ts
+++ b/tests/e2e/specs/series-reconnect-banner.spec.ts
@@ -23,7 +23,7 @@ import {
  * | frances | emmanuel | Ban | P2 navigates to home | Banner visible, click returns to pick page |
  */
 
-test.describe('frances vs emmanuel: Reconnection banner', () => {
+test.describe('frances vs emmanuel: Reconnection banner @phase:pick @feature:reconnect @scope:quick', () => {
   test.describe.configure({ timeout: 90000 });
 
   const pairUsers = ['frances', 'emmanuel'];

--- a/tests/e2e/specs/series-resting.spec.ts
+++ b/tests/e2e/specs/series-resting.spec.ts
@@ -26,20 +26,19 @@ import {
  * - Both players click "Next Game" → 3s countdown → transition to next phase
  * - 30s timeout → auto-transition without any clicks
  *
- * | # | P1 | P2 | Scenario |
- * |---|----|----|----------|
- * | 18 | yaroslava | ekaterina | Both confirm Next Game → fast transition (2 games) |
- * | 19 | margarita | yevgeny | Resting timeout → auto-transition (1 game + timeout) |
+ * | P1 | P2 | Scenario |
+ * |----|----|----|
+ * | yaroslava | ekaterina | Both confirm Next Game → fast transition (2 games) |
+ * | margarita | yevgeny | Resting timeout → auto-transition (1 game + timeout) |
  */
 
-// ===== Test 18: Both confirm Next Game quickly =====
-test.describe('Test 18: yaroslava vs ekaterina (Resting: both confirm)', () => {
+test.describe('yaroslava vs ekaterina: Resting both confirm', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['yaroslava', 'ekaterina'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 18] Resting UI appears after game → both confirm → next game starts', async ({ browser }) => {
+  test('Resting UI appears after game → both confirm → next game starts', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.yaroslava,
@@ -70,7 +69,7 @@ test.describe('Test 18: yaroslava vs ekaterina (Resting: both confirm)', () => {
       let game1Id = '';
       await test.step('Play game 1 (P2 resigns)', async () => {
         game1Id = await playOneGame(player1, player2, 'yaroslava', 'ekaterina', 'p2-resign');
-        console.log(`[Test 18] Game 1 finished: ${game1Id}`);
+        console.log(`[Resting Confirm] Game 1 finished: ${game1Id}`);
         await takeScreenshot('game1-result-p1', player1);
         await takeScreenshot('game1-result-p2', player2);
       });
@@ -88,7 +87,7 @@ test.describe('Test 18: yaroslava vs ekaterina (Resting: both confirm)', () => {
         const timeLeft = await getRestingTimeLeft(player1);
         expect(timeLeft).toBeGreaterThan(0);
         expect(timeLeft).toBeLessThanOrEqual(30);
-        console.log(`[Test 18] Resting timer: ${timeLeft}s`);
+        console.log(`[Resting Confirm] Resting timer: ${timeLeft}s`);
 
         // Verify "Next Game" button is visible
         await expect(player1.locator(selectors.restingConfirmBtn)).toBeVisible();
@@ -158,7 +157,7 @@ test.describe('Test 18: yaroslava vs ekaterina (Resting: both confirm)', () => {
 
         await takeScreenshot('game2-started-p1', player1);
         await takeScreenshot('game2-started-p2', player2);
-        console.log(`[Test 18] Game 2 started successfully`);
+        console.log(`[Resting Confirm] Game 2 started successfully`);
       });
     } finally {
       await player1Context.close();
@@ -167,15 +166,14 @@ test.describe('Test 18: yaroslava vs ekaterina (Resting: both confirm)', () => {
   });
 });
 
-// ===== Test 19: Resting timeout (no confirm) =====
-test.describe('Test 19: margarita vs yevgeny (Resting: timeout auto-transition)', () => {
+test.describe('margarita vs yevgeny: Resting timeout auto-transition', () => {
   // 30s resting timeout + phase transition + game start + buffer
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['margarita', 'yevgeny'];
   test.beforeAll(() => cleanupPairData(pairUsers));
 
-  test('[Test 19] No one clicks Next Game → 30s timeout → auto-transition', async ({ browser }) => {
+  test('No one clicks Next Game → 30s timeout → auto-transition', async ({ browser }) => {
     const { player1Context, player2Context, player1, player2 } = await createTwoPlayerContexts(
       browser,
       users.margarita,
@@ -206,7 +204,7 @@ test.describe('Test 19: margarita vs yevgeny (Resting: timeout auto-transition)'
       let game1Id = '';
       await test.step('Play game 1 (P1 resigns)', async () => {
         game1Id = await playOneGame(player1, player2, 'margarita', 'yevgeny', 'p1-resign');
-        console.log(`[Test 19] Game 1 finished: ${game1Id}`);
+        console.log(`[Resting Timeout] Game 1 finished: ${game1Id}`);
         await takeScreenshot('game1-result-p1', player1);
       });
 
@@ -216,7 +214,7 @@ test.describe('Test 19: margarita vs yevgeny (Resting: timeout auto-transition)'
         await waitForRestingUI(player2);
 
         const timeLeft = await getRestingTimeLeft(player1);
-        console.log(`[Test 19] Resting timer: ${timeLeft}s`);
+        console.log(`[Resting Timeout] Resting timer: ${timeLeft}s`);
         expect(timeLeft).toBeGreaterThan(0);
 
         await takeScreenshot('resting-ui-p1', player1);
@@ -246,7 +244,7 @@ test.describe('Test 19: margarita vs yevgeny (Resting: timeout auto-transition)'
 
       // Step 5: Wait for timeout (don't click anything) → auto-transition
       await test.step('Wait for 30s timeout → auto-transition to next game', async () => {
-        console.log('[Test 19] NOT clicking Next Game - waiting for 30s timeout...');
+        console.log('[Resting Timeout] NOT clicking Next Game - waiting for 30s timeout...');
 
         // Use skipResting=true so waitForNextGame doesn't click the button
         await waitForNextGame(player1, player2, null, game1Id, 50000, takeScreenshot, 2, true);
@@ -257,7 +255,7 @@ test.describe('Test 19: margarita vs yevgeny (Resting: timeout auto-transition)'
 
         await takeScreenshot('game2-auto-started-p1', player1);
         await takeScreenshot('game2-auto-started-p2', player2);
-        console.log(`[Test 19] Game 2 started via timeout auto-transition`);
+        console.log(`[Resting Timeout] Game 2 started via timeout auto-transition`);
       });
     } finally {
       await player1Context.close();

--- a/tests/e2e/specs/series-resting.spec.ts
+++ b/tests/e2e/specs/series-resting.spec.ts
@@ -32,7 +32,7 @@ import {
  * | margarita | yevgeny | Resting timeout → auto-transition (1 game + timeout) |
  */
 
-test.describe('yaroslava vs ekaterina: Resting both confirm', () => {
+test.describe('yaroslava vs ekaterina: Resting both confirm @phase:pick @phase:ban @phase:game @phase:resting @scope:slow', () => {
   test.describe.configure({ timeout: 120000 });
 
   const pairUsers = ['yaroslava', 'ekaterina'];
@@ -166,7 +166,7 @@ test.describe('yaroslava vs ekaterina: Resting both confirm', () => {
   });
 });
 
-test.describe('margarita vs yevgeny: Resting timeout auto-transition', () => {
+test.describe('margarita vs yevgeny: Resting timeout auto-transition @phase:pick @phase:ban @phase:game @phase:resting @scope:slow', () => {
   // 30s resting timeout + phase transition + game start + buffer
   test.describe.configure({ timeout: 120000 });
 

--- a/tests/e2e/specs/series-scenarios.spec.ts
+++ b/tests/e2e/specs/series-scenarios.spec.ts
@@ -76,7 +76,7 @@ for (const scenario of testScenarios) {
 
   const timeout = calculateTimeout(seriesResult, pick, ban);
 
-  test.describe(`${p1User.username} vs ${p2User.username}: ${description}`, () => {
+  test.describe(`${p1User.username} vs ${p2User.username}: ${description} @phase:pick @phase:ban @phase:game @phase:resting @phase:selecting @scope:slow`, () => {
     test.describe.configure({ timeout });
 
     test.beforeAll(() => cleanupPairData(pairUsers));


### PR DESCRIPTION
## Summary
- 테스트 번호(`[Test N]`) 전체 제거 → 서술적 이름으로 변경 (중복 번호 문제 해결)
- `@phase:*`, `@feature:*`, `@scope:*` 태그 추가 → 관심사별 필터 실행 가능
- `series-banpick.spec.ts` → `series-scenarios.spec.ts` 리네이밍
- MongoDB 컨테이너 이름 수정 (`chess-opening-duel-mongodb-1` → `app-mongodb-1`)
- NoStart timer 테스트 flaky 수정: 유저 쌍 분리(`monica/yun`) + 유저 검색 정확 매칭

## Test plan
- [x] 태그 필터 동작 확인 (`--grep @feature:disconnect`, `@scope:quick`, `@phase:resting`)
- [x] nostart 3개 테스트 통과
- [x] 전체 E2E: 33 passed, 2 failed (기존 opening-pool-customize 버그 + nostart flaky → 수정 후 nostart 통과)

🤖 Generated with [Claude Code](https://claude.com/claude-code)